### PR TITLE
stop publishing metrics at runtime

### DIFF
--- a/packages/core/glue.d.ts
+++ b/packages/core/glue.d.ts
@@ -1612,6 +1612,7 @@ export namespace Glue42Core {
             activityId?: string;
             activityWindowId?: string;
         };
+        getMetricsPublishingEnabled: () => boolean;
     }
 
     export interface LoggerConfig {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -138,9 +138,13 @@ const GlueCore = (userConfig?: Glue42Core.Config, ext?: Glue42Core.Extension): P
         const initTimer = timer();
         const config = internalConfig.metrics;
 
+        const metricsPublishingEnabledFunc = glue42gd?.getMetricsPublishingEnabled;
+        const canUpdateMetric = metricsPublishingEnabledFunc ? metricsPublishingEnabledFunc : () => true;
+
         const rootMetrics = metrics({
             connection: config ? _connection : undefined,
-            logger: _logger.subLogger("metrics")
+            logger: _logger.subLogger("metrics"),
+            canUpdateMetric
         });
 
         let rootSystem = rootMetrics;

--- a/packages/core/src/metrics/types.ts
+++ b/packages/core/src/metrics/types.ts
@@ -9,6 +9,7 @@ export interface MetricsSettings {
     /** If true will auto create click stream metrics in root system */
     clickStream?: boolean;
     settings?: object;
+    canUpdateMetric: () => boolean;
 }
 
 export interface Protocol {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -40,6 +40,8 @@ export interface GDObject {
         gwToken: string,
         isOwner: boolean
     };
+
+    getMetricsPublishingEnabled: () => boolean;
     updatePerfData: (perf: object) => void;
     getGWToken(): Promise<string>;
     getWindowInfo(id: string): {


### PR DESCRIPTION
Users need to be able to control (stop/start) the metrics being published by JS applications. This needs to be done dynamically.

Acceptance Criteria

1. Select application 
2. Run instance, Metrics Viewer and verify you can see metrics from the selected application;
5. Disable metrics publishing; look at the Metrics Viewer and check that there are NO updated (e.g. in FAV metric section ) from our instance;
6. Enable metrics publishing - FAV metric for the selected app in Metrics Viewer should be publishing updates again.