### PR TITLE
Renamed tutorial titles (ReactJS tutorial)

### DIFF
--- a/tutorials/react/solution/index.html
+++ b/tutorials/react/solution/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Glue42 Core Vanilla-JS Tutorial</title>
+    <title>Glue42 Core ReactJS Tutorial</title>
     <style>
         body,
         html {

--- a/tutorials/react/start/index.html
+++ b/tutorials/react/start/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Glue42 Core Vanilla-JS Tutorial</title>
+    <title>Glue42 Core ReactJS Tutorial</title>
     <style>
         body,
         html {


### PR DESCRIPTION
Renamed the titles (in start and solution index.html) tutorial for ReactJS
**from** Glue42 Core Vanilla-JS Tutorial 
**to** Glue42 Core ReactJS Tutorial