### PR TITLE
Extend the CLI with workspaces functionalities

### DIFF
--- a/packages/cli-core/package-lock.json
+++ b/packages/cli-core/package-lock.json
@@ -1335,9 +1335,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
 			"dev": true
 		},
 		"lodash.isequal": {

--- a/packages/cli-core/src/cli.ts
+++ b/packages/cli-core/src/cli.ts
@@ -19,5 +19,5 @@ export const initiate = async (process: NodeJS.Process): Promise<void> => {
 
     return commands
         .find((command) => command.name === cliConfig.command)
-        .action(cliConfig, logger);
+        .action(cliConfig, logger, process.argv);
 };

--- a/packages/cli-core/src/commands.ts
+++ b/packages/cli-core/src/commands.ts
@@ -6,15 +6,23 @@ import { initController } from "./initiate";
 import { serverDecoderDecorator } from "./config/config-decoders";
 import { Decoder } from "@mojotech/json-type-validation";
 import { versionController } from "./version";
+import { workspacesController } from "./workspaces";
 
 export interface CommandDefinition {
     name: CliCommand;
-    action: (config: CliConfig, logger: Logger) => Promise<void>;
+    action: (config: CliConfig, logger: Logger, argv?: string[]) => Promise<void>;
     requiredConfig: boolean;
     decoderDecorator?: Decoder<unknown>;
 }
 
 export const commands: CommandDefinition[] = [
+    {
+        name: "workspaces",
+        action: async (config: CliConfig, logger: Logger, argv: string[]): Promise<void> => {
+            await workspacesController.processWorkspacesCommand(config, logger, argv);
+        },
+        requiredConfig: true
+    },
     {
         name: "serve",
         action: async (config: CliConfig, logger: Logger): Promise<void> => {            

--- a/packages/cli-core/src/config/cli.config.d.ts
+++ b/packages/cli-core/src/config/cli.config.d.ts
@@ -33,6 +33,7 @@ export interface CliGlueAssets {
         manifestLocation: string;
     };
     config: string;
+    layouts: string;
     route: string;
 }
 

--- a/packages/cli-core/src/config/cli.config.d.ts
+++ b/packages/cli-core/src/config/cli.config.d.ts
@@ -1,10 +1,11 @@
 import { ServerApp, ServerSettings, SharedAsset } from "./user.config";
 
-export type CliCommand = "serve" | "build" | "init" | "version";
+export type CliCommand = "serve" | "build" | "init" | "version" | "workspaces";
 
 export interface CliConfig extends FullDevConfig {
     rootDirectory: string;
     command: CliCommand;
+    workspaces: boolean;
 }
 
 export interface FullDevConfig {
@@ -26,6 +27,10 @@ export interface CliGlueAssets {
     gateway: {
         location: string;
         gwLogAppender?: string;
+    };
+    workspaces?: {
+        appLocation: string;
+        manifestLocation: string;
     };
     config: string;
     route: string;

--- a/packages/cli-core/src/config/config-decoders.ts
+++ b/packages/cli-core/src/config/config-decoders.ts
@@ -33,7 +33,12 @@ export const glueDevConfigDecoder: Decoder<GlueDevConfig> = object({
             gwLogAppender: optional(nonEmptyStringDecoder)
         })),
         config: optional(nonEmptyStringDecoder),
-        route: optional(nonEmptyStringDecoder)
+        route: optional(nonEmptyStringDecoder),
+        workspaces: optional(object({
+            appLocation: nonEmptyStringDecoder,
+            manifestLocation: nonEmptyStringDecoder
+        })),
+        layouts: optional(nonEmptyStringDecoder)
     })),
     server: optional(object({
         apps: array(userServerAppDecoder),

--- a/packages/cli-core/src/config/controller.ts
+++ b/packages/cli-core/src/config/controller.ts
@@ -94,7 +94,7 @@ export class ConfigController {
 
         const hasWorkspaces = processArgv.some((arg) => arg.includes("--workspaces")) ||
             processArgv.some((arg) => arg.includes("-w")) ||
-            !!userConfig.glueAssets.workspaces;
+            !!userConfig.glueAssets?.workspaces;
 
         return Object.assign({}, { rootDirectory, command: command.name }, mergedConfig, { workspaces: hasWorkspaces });
     }

--- a/packages/cli-core/src/config/controller.ts
+++ b/packages/cli-core/src/config/controller.ts
@@ -17,14 +17,14 @@ export class ConfigController {
 
         const userConfig = await this.getUserDefinedConfig(cwd, command);
 
-        const cliConfig = this.mergeDefaults(userConfig, cwd, command);
+        const cliConfig = this.mergeDefaults(userConfig, cwd, command, process.argv);
 
         this.transFormAllToAbsolute(cliConfig, cwd);
 
         if (command.requiredConfig) {
             await this.validateExistence(cliConfig);
         }
-        
+
         return cliConfig;
     }
 
@@ -83,7 +83,7 @@ export class ConfigController {
         ];
     }
 
-    private mergeDefaults(userConfig: GlueDevConfig, rootDirectory: string, command: CommandDefinition): CliConfig {
+    private mergeDefaults(userConfig: GlueDevConfig, rootDirectory: string, command: CommandDefinition, processArgv: string[]): CliConfig {
         const defaults = glueDevConfigDefaults.data;
 
         if (userConfig.server?.apps) {
@@ -92,7 +92,11 @@ export class ConfigController {
 
         const mergedConfig = (deepMerge(defaults, userConfig) as FullDevConfig);
 
-        return Object.assign({}, { rootDirectory, command: command.name }, mergedConfig);
+        const hasWorkspaces = processArgv.some((arg) => arg.includes("--workspaces")) ||
+            processArgv.some((arg) => arg.includes("-w")) ||
+            !!userConfig.glueAssets.workspaces;
+
+        return Object.assign({}, { rootDirectory, command: command.name }, mergedConfig, { workspaces: hasWorkspaces });
     }
 
     private addCookieIds(apps: ServerApp[]): CliServerApp[] {

--- a/packages/cli-core/src/config/user.config.d.ts
+++ b/packages/cli-core/src/config/user.config.d.ts
@@ -19,6 +19,7 @@ export interface GlueAssets {
     };
     worker?: string;
     config?: string;
+    layouts?: string;
     route?: string;
 }
 

--- a/packages/cli-core/src/config/user.config.d.ts
+++ b/packages/cli-core/src/config/user.config.d.ts
@@ -13,6 +13,10 @@ export interface GlueAssets {
         location?: string;
         gwLogAppender?: string;
     };
+    workspaces?: {
+        appLocation: string;
+        manifestLocation: string;
+    };
     worker?: string;
     config?: string;
     route?: string;

--- a/packages/cli-core/src/defaults.ts
+++ b/packages/cli-core/src/defaults.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Configuration } from "log4js";
 import { FullDevConfig } from "./config/cli.config.d";
 
@@ -25,6 +26,14 @@ export const workspacesDefaults = {
     manifestLocation: "./workspaces.webmanifest"
 };
 
+export const layoutsDefaults: { name: string; data: { globals: any[]; workspaces: any[] } } = {
+    name: "glue.layouts.json",
+    data: {
+        globals: [],
+        workspaces: []
+    }
+};
+
 export const glueDevConfigDefaults: { name: string; location: string; data: FullDevConfig } = {
     location: "./",
     name: "glue.config.dev.json",
@@ -35,6 +44,7 @@ export const glueDevConfigDefaults: { name: string; location: string; data: Full
             },
             worker: "./node_modules/@glue42/worker-web/dist/worker.js",
             config: "./glue.config.json",
+            layouts: "./glue.layouts.json",
             route: "/glue"
         },
         server: {

--- a/packages/cli-core/src/defaults.ts
+++ b/packages/cli-core/src/defaults.ts
@@ -18,6 +18,13 @@ export const loggerConfig: Configuration = {
 
 export const gCoreDeps = ["@glue42/gateway-web", "@glue42/worker-web"];
 
+export const workspacesDeps = ["@glue42/workspaces-app"];
+
+export const workspacesDefaults = {
+    appLocation: "./node_modules/@glue42/workspaces-app",
+    manifestLocation: "./workspaces.webmanifest"
+};
+
 export const glueDevConfigDefaults: { name: string; location: string; data: FullDevConfig } = {
     location: "./",
     name: "glue.config.dev.json",

--- a/packages/cli-core/src/initiate/controller.ts
+++ b/packages/cli-core/src/initiate/controller.ts
@@ -4,16 +4,27 @@ import { Npm } from "./npm";
 import { gCoreDeps, glueConfigDefaults, glueDevConfigDefaults } from "../defaults";
 import { CliConfig } from "../config/cli.config";
 import { Logger } from "log4js";
+import { WorkspacesController } from "../workspaces/controller";
 
 export class InitiationController {
 
     private logger: Logger;
 
-    constructor(private readonly npm: Npm) { }
+    constructor(
+        private readonly npm: Npm,
+        private readonly workspacesController: WorkspacesController
+    ) { }
 
     public async start(config: CliConfig, logger: Logger): Promise<void> {
-        
+
         this.logger = logger;
+
+        const configExists = await this.checkConfigExists(config.rootDirectory);
+
+        if (configExists) {
+            this.logger.warn("Glue42 Core is already initialized in this directory. Skipping...");
+            return;
+        }
 
         const pJsonExists = await this.checkPJsonExists(config.rootDirectory);
 
@@ -26,17 +37,31 @@ export class InitiationController {
         this.logger.info(`Installing Glue42 Core deps: ${gCoreDeps.join(" ")}`);
 
         await this.npm.installDeps(gCoreDeps);
+
         await Promise.all([
             this.createFile(join(config.rootDirectory, glueDevConfigDefaults.name), JSON.stringify(glueDevConfigDefaults.data, null, 4)),
             this.createFile(join(config.rootDirectory, glueConfigDefaults.name), JSON.stringify(glueConfigDefaults.data, null, 4)),
         ]);
 
+        if (config.workspaces) {
+            await this.workspacesController.start(config, logger);
+        }
+
         this.logger.info("Glue42 Core development environment completed");
     }
 
     private checkPJsonExists(rootDirectory: string): Promise<boolean> {
-        return new Promise<boolean>((resolve) => {
-            const location = join(rootDirectory, "package.json");
+        const location = join(rootDirectory, "package.json");
+        return this.accessPromise(location);
+    }
+
+    private checkConfigExists(rootDirectory: string): Promise<boolean> {
+        const configLocation = join(rootDirectory, glueDevConfigDefaults.name);
+        return this.accessPromise(configLocation);
+    }
+
+    private accessPromise(location: string): Promise<boolean> {
+        return new Promise((resolve) => {
             access(location, constants.F_OK, (err) => {
                 if (err) {
                     return resolve(false);

--- a/packages/cli-core/src/initiate/controller.ts
+++ b/packages/cli-core/src/initiate/controller.ts
@@ -1,7 +1,7 @@
 import { access, constants, writeFile } from "fs";
 import { join } from "path";
 import { Npm } from "./npm";
-import { gCoreDeps, glueConfigDefaults, glueDevConfigDefaults } from "../defaults";
+import { gCoreDeps, glueConfigDefaults, glueDevConfigDefaults, layoutsDefaults } from "../defaults";
 import { CliConfig } from "../config/cli.config";
 import { Logger } from "log4js";
 import { WorkspacesController } from "../workspaces/controller";
@@ -41,6 +41,7 @@ export class InitiationController {
         await Promise.all([
             this.createFile(join(config.rootDirectory, glueDevConfigDefaults.name), JSON.stringify(glueDevConfigDefaults.data, null, 4)),
             this.createFile(join(config.rootDirectory, glueConfigDefaults.name), JSON.stringify(glueConfigDefaults.data, null, 4)),
+            this.createFile(join(config.rootDirectory, layoutsDefaults.name), JSON.stringify(layoutsDefaults.data, null, 4)),
         ]);
 
         if (config.workspaces) {

--- a/packages/cli-core/src/initiate/index.ts
+++ b/packages/cli-core/src/initiate/index.ts
@@ -1,5 +1,6 @@
 import { InitiationController } from "./controller";
 import { Npm } from "./npm";
+import { workspacesController } from "../workspaces";
 
 const npm = new Npm();
-export const initController = new InitiationController(npm);
+export const initController = new InitiationController(npm, workspacesController);

--- a/packages/cli-core/src/server/server.ts
+++ b/packages/cli-core/src/server/server.ts
@@ -249,13 +249,26 @@ export class CoreDevServer {
         const glueAssets = [
             { route: `${this.config.glueAssets.route}/worker.js`, resolveWith: this.config.glueAssets.worker },
             { route: `${this.config.glueAssets.route}/gateway.js`, resolveWith: this.config.glueAssets.gateway.location },
-            { route: `${this.config.glueAssets.route}/glue.config.json`, resolveWith: this.config.glueAssets.config }
+            { route: `${this.config.glueAssets.route}/glue.config.json`, resolveWith: this.config.glueAssets.config },
+            { route: `${this.config.glueAssets.route}/glue.layouts.json`, resolveWith: this.config.glueAssets.layouts }
         ];
 
         if (this.config.glueAssets.gateway.gwLogAppender) {
             glueAssets.push({
                 route: `${this.config.glueAssets.route}/gwLogAppender.js`,
                 resolveWith: this.config.glueAssets.gateway.gwLogAppender
+            });
+        }
+
+        if (this.config.glueAssets.workspaces) {
+            glueAssets.push({
+                route: `${this.config.glueAssets.route}/workspaces/workspaces.webmanifest`,
+                resolveWith: this.config.glueAssets.workspaces.manifestLocation
+            });
+
+            glueAssets.push({
+                route: `${this.config.glueAssets.route}/workspaces`,
+                resolveWith: this.config.glueAssets.workspaces.appLocation
             });
         }
 

--- a/packages/cli-core/src/workspaces/controller.ts
+++ b/packages/cli-core/src/workspaces/controller.ts
@@ -1,0 +1,99 @@
+import { Npm } from "../initiate/npm";
+import { join } from "path";
+import { readFile, writeFile, constants, access, copyFile } from "fs";
+import { workspacesDeps, workspacesDefaults, glueDevConfigDefaults } from "../defaults";
+import { CliConfig, FullDevConfig } from "../config/cli.config";
+import { Logger } from "log4js";
+
+export class WorkspacesController {
+    constructor(private readonly npm: Npm) { }
+
+    public async processWorkspacesCommand(config: CliConfig, logger: Logger, argv: string[]): Promise<void> {
+        const workspacesCommand = argv[3];
+
+        if (workspacesCommand === "init") {
+            await this.start(config, logger);
+            return;
+        }
+    }
+
+    public async start(config: CliConfig, logger: Logger): Promise<void> {
+        const configExists = await this.checkConfigExists(config);
+
+        if (!configExists) {
+            throw new Error("Glue42 Core must be initiated before workspaces can be added. Please run gluec init and then try again");
+        }
+
+        logger.info(`Installing Glue42 Core Workspaces deps: ${workspacesDeps.join(" ")}`);
+        await this.npm.installDeps(workspacesDeps);
+
+        await this.copyManifest(config);
+        logger.info(`Workspaces manifest ready at: ${join(config.rootDirectory, "workspaces.webmanifest")}`);
+
+        await this.decorateDevConfig(config);
+        logger.info("The Glue42 Core dev config was decorated, workspaces is initialized.");
+    }
+
+    private async decorateDevConfig(config: CliConfig): Promise<void> {
+        const defaults = workspacesDefaults;
+        const configLocation = join(config.rootDirectory, glueDevConfigDefaults.name);
+
+        const devConfig = await this.read(configLocation);
+        devConfig.glueAssets.workspaces = defaults;
+
+        await this.write(configLocation, devConfig);
+    }
+
+    private read(location: string): Promise<FullDevConfig> {
+        return new Promise((resolve, reject) => {
+            readFile(location, "utf8", (err, data) => {
+                if (err) {
+                    return reject(err);
+                }
+
+                resolve(JSON.parse(data));
+            });
+        });
+    }
+
+    private async write(location: string, data: FullDevConfig): Promise<void> {
+        return new Promise((resolve, reject) => {
+            writeFile(location, JSON.stringify(data), (err) => {
+                if (err) {
+                    return reject(err);
+                }
+
+                resolve();
+            });
+        });
+    }
+
+    private checkConfigExists(config: CliConfig): Promise<boolean> {
+        return new Promise<boolean>((resolve) => {
+
+            const configLocation = join(config.rootDirectory, glueDevConfigDefaults.name);
+
+            access(configLocation, constants.F_OK, (err) => {
+                if (err) {
+                    return resolve(false);
+                }
+                resolve(true);
+            });
+        });
+    }
+
+    private async copyManifest(config: CliConfig): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const source = join(config.rootDirectory, "node_modules", "@glue42", "workspaces-app", "manifest.webmanifest");
+            const destination = join(config.rootDirectory, "workspaces.webmanifest");
+    
+            copyFile(source, destination, (err) => {
+                if (err) {
+                    return reject(err);
+                }
+
+                resolve();
+            });
+        });
+    }
+}

--- a/packages/cli-core/src/workspaces/index.ts
+++ b/packages/cli-core/src/workspaces/index.ts
@@ -1,0 +1,5 @@
+import { WorkspacesController } from "./controller";
+import { Npm } from "../initiate/npm";
+
+const npm = new Npm();
+export const workspacesController = new WorkspacesController(npm);


### PR DESCRIPTION
added:
gluec init -w (sets up a new Glue42 Core environment with workspaces)
gluec workspaces init (adds workspaces to an existing Glue42 Core environment)

extended:
gluec serve (now is aware if workspaces are initialized and serves those assets too)
gluec build (now is aware if workspaces are initialized and build those assets too)