### PR TITLE
Add a way for @glue42/fdc3 to accept the application's name

### DIFF
--- a/docs/core/03_capabilities/99_fdc3-compliance/fdc3-compliance.md
+++ b/docs/core/03_capabilities/99_fdc3-compliance/fdc3-compliance.md
@@ -63,6 +63,15 @@ In **Glue42 Core**, Intents are defined in the application definitions in the `g
 - `displayName` - The human readable name of the Intent. Can be used in context menus, etc., to visualize the Intent;
 - `contexts` - **Required**. The type of predefined data structures that the application can work with (see [FDC3 Contexts](https://fdc3.finos.org/docs/next/context/overview)).
 
+In order to be able to properly target applications with `raiseIntent()` the applications need to pass their application name to `@glue42/fdc3`. This is needed by the implementation so it can check whether there is a running instance of the targeted application or a new instance has to be started. Because the FDC3 specification doesn't specify any initialization logic, `@glue42/fdc3` relies on a global variable called `fdc3AppName` being present prior to importing `@glue42/fdc3`:
+
+```html
+<script>
+    window.fdc3AppName = "TradingView Blotter";
+</script>
+<script src="https://unpkg.com/@glue42/fdc3@latest/dist/fdc3-glue42.js"></script>
+```
+
 *For more information on using intents, see the [FDC3 Intents API](https://fdc3.finos.org/docs/next/intents/overview).*
 
 ### Channels
@@ -86,6 +95,10 @@ All system defined Channels in **Glue42 Core** can be found in the `glue.config.
     ]
 }
 ```
+
+All Glue42 Core channels are available as FDC3 system channels.
+
+Glue42 Core applications can interact with FDC3 app channels by using the [Shared Contexts API](../shared-contexts/index.html). For each FDC3 app channel there is a shard context with the same name. You can use the `get()`, `set()`, `update()` and `subscribe()` methods to interact with it.
 
 *For a sample Channel Selector widget implementation, see the [**Channels: Channel Selector UI**](../channels/index.html#channel_selector_ui) section. There you can see example implementations for the most popular JavaScript frameworks. Note that internally the examples use the **Glue42 Core** Channels API and not the FDC3 Channels API.*
 
@@ -150,10 +163,12 @@ Below is an example FDC3 application definition:
 
 ### Demo
 
-Example of the `broadcast()` and `addContextListener()` API calls implemented by `@glue42/fdc3` are available in [this demo](https://fdc3-demo.glue42.com).
+Example of the `broadcast()` and `addContextListener()`, `findIntentsByContext()` and `raiseIntent()` API calls implemented by `@glue42/fdc3` are available in [this demo](https://fdc3-demo.glue42.com).
 
 The demo consists of a Chart and a Blotter application. Searching and selecting a ticker inside the Chart application adds it to the Blotter application as long as the two applications are on the same Channel (use the Channel Selector widget to navigate between Channels):
 
 ![FDC3 Demo](../../../images/fdc3/fdc3-demo.gif)
+
+Right-clicking on an instrument inside the Blotter opens up a context menu with the intents that can be raised for the instrument. When the chart application is running it would update its context and when there are no instances of the Chart application running it will start a new instance with the given context.
 
 You can use the [code of the demo](https://github.com/Glue42/fdc3-demos/tree/configure-for-glue42-core) as a reference when adapting your own applications.

--- a/live-examples/app-manager/app-manager-events/app-b/index.js
+++ b/live-examples/app-manager/app-manager-events/app-b/index.js
@@ -15,14 +15,15 @@ function subscribeToAppManagerEvents() {
 
   glue.appManager.onInstanceStarted(instance => {
     const instanceId = instance.id;
+    const appName = instance.application.name;
 
     // When it is my window - do not log. Keep the logs list clean.
     if (!isMyInstance(instanceId)) {
-      logger.info(`Instance with id "${instanceId}" started.`);
+      logger.info(`Instance of app ${appName} with id "${instanceId}" started.`);
     }
   });
 
   glue.appManager.onInstanceStopped(instance => {
-    logger.info(`Instance with id "${instance.id}" stopped.`);
+    logger.info(`Instance of app ${appName} with id "${instance.id}" stopped.`);
   });
 }

--- a/packages/fdc3/src/utils.ts
+++ b/packages/fdc3/src/utils.ts
@@ -1,5 +1,6 @@
 import { Glue42 } from "@glue42/desktop";
 import { Glue42Web } from "@glue42/web";
+import { WindowType } from "./windowtype";
 
 /**
  * Changes to subscribe to comply with the FDC3 specification:
@@ -7,23 +8,40 @@ import { Glue42Web } from "@glue42/web";
  * 2. Ignore initial replay
  */
 export const decorateContextApi = (glue: Glue42.Glue | Glue42Web.API): Glue42.Glue | Glue42Web.API => {
-    glue.contexts.subscribe = (name: string, callback: (data: any, delta: any, removed: string[], unsubscribe: () => void, extraData?: any) => void): Promise<() => void> => {
+    const newGlue = { ...glue, contexts: { ...glue.contexts } };
+
+    newGlue.contexts.subscribe = (name: string, callback: (data: any, delta: any, removed: string[], unsubscribe: () => void, extraData?: any) => void): Promise<() => void> => {
         let didReplay = false;
-        return glue.contexts.subscribe(name, (data: any, delta: any, removed: string[], unsubscribe: () => void, extraData?: any) => {
+        return newGlue.contexts.subscribe(name, (data: any, delta: any, removed: string[], unsubscribe: () => void, extraData?: any) => {
             if (!didReplay) {
                 didReplay = true;
                 return;
             }
- 
+
             const updateFromMe = extraData.updaterId === glue.interop.instance.instance;
- 
+
             if (!updateFromMe) {
                 callback(data, delta, removed, unsubscribe, extraData);
             }
         });
     };
- 
-    return glue;
+
+    return newGlue as Glue42.Glue | Glue42Web.API;
+};
+
+/**
+ * Returns a list of all channel contexts. We are not using `glue.channels.list()` so that @glue42/fdc3 can be used with older versions of the Glue42 JS SDK.
+ */
+export const getChannelsList = async () => {
+    const channelNames = await (window as WindowType).glue.channels.all();
+    const channelContents: Array<Glue42.Channels.ChannelContext> =
+        await Promise.all(channelNames.map((name: string) => (window as WindowType).glue.channels.get(name)));
+
+    return channelContents;
+};
+
+export const isEmptyObject = (obj: object): boolean => {
+    return Object.keys(obj).length === 0 && obj.constructor === Object;
 };
 
 export const isGlue42Core = !navigator.userAgent.toLowerCase().includes(" electron/");

--- a/packages/fdc3/src/windowtype.d.ts
+++ b/packages/fdc3/src/windowtype.d.ts
@@ -3,6 +3,8 @@ import { Glue42Web } from "@glue42/web";
 
 export type WindowType = (typeof window) & {
   glue: Glue42.Glue | Glue42Web.API;
-  gluePromise: Promise<Glue42.Glue | Glue42Web.API>;
+  gluePromise: Promise<void | Glue42.Glue | Glue42Web.API>;
   glue42gd?: Glue42.GDObject;
+  fdc3AppName?: string;
+  Glue?: (config?: Glue42.Config) => Promise<Glue42.Glue>;
 }


### PR DESCRIPTION
Fix an issue where the context was updated an additional time
Update the @glue42/fdc3 package versioning
Remove the usage of `glue.channels.list()` for backwards compatibility
Use the auto injected Glue factory function when it is available
Fix an issue with `decorateContextApi()`
Display the newly opened/closed application name inside of the AppManager live example
Update the FDC3 documentation