### PR TITLE
Fix a bug where `getOrCreateChannel()` was not returning system channels

### DIFF
--- a/e2e/tests/Example/example.spec.js
+++ b/e2e/tests/Example/example.spec.js
@@ -1,7 +1,7 @@
 describe('it should work', () => {
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     it('should have Glue42 Web version', async () => {

--- a/e2e/tests/Workspaces/API/createWorkspace.spec.js
+++ b/e2e/tests/Workspaces/API/createWorkspace.spec.js
@@ -1,7 +1,7 @@
 describe('createWorkspace() ', function () {
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     afterEach(async () => {

--- a/e2e/tests/Workspaces/API/getAllFrames.spec.js
+++ b/e2e/tests/Workspaces/API/getAllFrames.spec.js
@@ -18,7 +18,7 @@ describe('getAllFrames() Should ', function () {
     // TODO check the close() case
     // TODO predicate tests
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/API/getAllWorkspaces.spec.js
+++ b/e2e/tests/Workspaces/API/getAllWorkspaces.spec.js
@@ -13,7 +13,7 @@ describe('getAllWorkspaces() Should ', function () {
         ]
     }
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
     // TODO add predicate tests
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/API/getAllWorkspacesSummaries.spec.js
+++ b/e2e/tests/Workspaces/API/getAllWorkspacesSummaries.spec.js
@@ -14,7 +14,7 @@ describe('getAllWorkspacesSummaries() Should ', function () {
     }
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/API/getFrame.spec.js
+++ b/e2e/tests/Workspaces/API/getFrame.spec.js
@@ -21,7 +21,7 @@ describe("getFrame() Should", () => {
     let workspaceThree = undefined;
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         workspaceOne = await glue.workspaces.createWorkspace(basicConfig);
         workspaceTwo = await glue.workspaces.createWorkspace(basicConfig);
         workspaceThree = await glue.workspaces.createWorkspace(basicConfig);

--- a/e2e/tests/Workspaces/API/getMyFrame.spec.js
+++ b/e2e/tests/Workspaces/API/getMyFrame.spec.js
@@ -14,7 +14,7 @@ describe('getMyFrame() Should ', function () {
     }
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/API/getMyWorkspace.spec.js
+++ b/e2e/tests/Workspaces/API/getMyWorkspace.spec.js
@@ -14,7 +14,7 @@ describe('getMyWorkspace() Should ', function () {
     }
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/API/getParent.spec.js
+++ b/e2e/tests/Workspaces/API/getParent.spec.js
@@ -42,7 +42,7 @@ describe("getBox() Should", () => {
     let workspace = undefined;
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         workspace = await glue.workspaces.createWorkspace(basicConfig);
     });
 

--- a/e2e/tests/Workspaces/API/getWindow.spec.js
+++ b/e2e/tests/Workspaces/API/getWindow.spec.js
@@ -42,7 +42,7 @@ describe("getWindow() Should", () => {
     let workspace = undefined;
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
 
         workspace = await glue.workspaces.createWorkspace(basicConfig);
     });

--- a/e2e/tests/Workspaces/API/getWorkspace.spec.js
+++ b/e2e/tests/Workspaces/API/getWorkspace.spec.js
@@ -21,7 +21,7 @@ describe("getWorkspace() Should", () => {
     let workspaceThree = undefined;
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
 
         workspaceOne = await glue.workspaces.createWorkspace(basicConfig);
         workspaceTwo = await glue.workspaces.createWorkspace(basicConfig);

--- a/e2e/tests/Workspaces/API/inWorkspace.spec.js
+++ b/e2e/tests/Workspaces/API/inWorkspace.spec.js
@@ -14,7 +14,7 @@ describe('inWorkspace() Should ', function () {
     }
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/API/layouts/delete.spec.js
+++ b/e2e/tests/Workspaces/API/layouts/delete.spec.js
@@ -14,7 +14,7 @@ describe('delete() Should ', function () {
     }
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     let layoutsForCleanup = [];

--- a/e2e/tests/Workspaces/API/layouts/export.spec.js
+++ b/e2e/tests/Workspaces/API/layouts/export.spec.js
@@ -16,7 +16,7 @@ describe('export() Should ', function () {
     let layoutsForCleanup = [];
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     afterEach(async () => {
@@ -44,7 +44,7 @@ describe('export() Should ', function () {
             await Promise.all(savePromises);
 
             const layouts = await glue.workspaces.layouts.export();
-            const exportedLayouts =layouts.filter(s => s.name.startsWith("layout")); 
+            const exportedLayouts = layouts.filter(s => s.name.startsWith("layout"));
 
             expect(exportedLayouts.length).to.eql(i + 1);
         });

--- a/e2e/tests/Workspaces/API/layouts/getSummaries.spec.js
+++ b/e2e/tests/Workspaces/API/layouts/getSummaries.spec.js
@@ -13,7 +13,7 @@ describe('getSummaries() Should ', function () {
         ]
     }
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     let layoutsForCleanup = [];

--- a/e2e/tests/Workspaces/API/layouts/import.spec.js
+++ b/e2e/tests/Workspaces/API/layouts/import.spec.js
@@ -30,7 +30,7 @@ describe('import() Should ', function () {
         ]
     }
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         const workspace = await glue.workspaces.createWorkspace(basicConfig);
         await workspace.saveLayout("layout.random.1");
         basicImport = (await glue.workspaces.layouts.export()).find(l => l.name === "layout.random.1");

--- a/e2e/tests/Workspaces/API/restoreWorkspace.spec.js
+++ b/e2e/tests/Workspaces/API/restoreWorkspace.spec.js
@@ -18,7 +18,7 @@ describe('restoreWorkspace() Should', function () {
     const layoutName = "layout.integration.tests";
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/Frame/close.spec.js
+++ b/e2e/tests/Workspaces/Frame/close.spec.js
@@ -14,7 +14,7 @@ describe("maximize() Should", () => {
     };
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     let workspace;

--- a/e2e/tests/Workspaces/Frame/properties.spec.js
+++ b/e2e/tests/Workspaces/Frame/properties.spec.js
@@ -44,7 +44,7 @@ describe("properties: ", () => {
     let workspace;
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         workspace = await glue.workspaces.createWorkspace(threeContainersConfig);
     });
 

--- a/e2e/tests/Workspaces/Frame/restoreWorkspace.spec.js
+++ b/e2e/tests/Workspaces/Frame/restoreWorkspace.spec.js
@@ -19,7 +19,7 @@ describe('restoreWorkspace() Should', function () {
     const layoutName = "layout.integration.tests";
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/Parent/addColumn.spec.js
+++ b/e2e/tests/Workspaces/Parent/addColumn.spec.js
@@ -38,7 +38,7 @@ describe("addColumn() Should", () => {
 
     let workspace = undefined;
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {
@@ -240,11 +240,11 @@ describe("addColumn() Should", () => {
             const firstContext = {
                 first: true
             };
-    
+
             const secondContext = {
                 second: true
             };
-    
+
             const column = await row.addColumn({
                 children: [
                     {
@@ -259,17 +259,17 @@ describe("addColumn() Should", () => {
                     }
                 ]
             });
-    
+
             await Promise.all(column.children.map((w) => w.forceLoad()));
             await workspace.refreshReference();
-    
+
             const wait = new Promise((r) => setTimeout(r, 3000));
             await wait;
-    
+
             await Promise.all(column.children.map(async (w, i) => {
                 const glueWin = w.getGdWindow();
                 const winContext = await glueWin.getContext();
-    
+
                 if (winContext.first) {
                     expect(winContext).to.eql(firstContext);
                 } else if (winContext.second) {

--- a/e2e/tests/Workspaces/Parent/addGroup.spec.js
+++ b/e2e/tests/Workspaces/Parent/addGroup.spec.js
@@ -38,7 +38,7 @@ describe("addGroup() Should", () => {
 
     let workspace = undefined;
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {
@@ -195,7 +195,7 @@ describe("addGroup() Should", () => {
         const secondContext = {
             second: true
         };
-        
+
         const group = await column.addGroup({
             children: [
                 {

--- a/e2e/tests/Workspaces/Parent/addRow.spec.js
+++ b/e2e/tests/Workspaces/Parent/addRow.spec.js
@@ -38,7 +38,7 @@ describe("addRow() Should", () => {
 
     let workspace = undefined;
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {
@@ -119,7 +119,7 @@ describe("addRow() Should", () => {
         const secondContext = {
             second: true
         };
-        
+
         const row = await column.addRow({
             children: [
                 {

--- a/e2e/tests/Workspaces/Parent/addWindow.spec.js
+++ b/e2e/tests/Workspaces/Parent/addWindow.spec.js
@@ -38,7 +38,7 @@ describe("addWindow() Should", () => {
 
     let workspace = undefined;
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {
@@ -135,16 +135,16 @@ describe("addWindow() Should", () => {
                     appName: "dummyApp",
                     context
                 });
-    
+
                 await window.forceLoad();
                 await workspace.refreshReference();
-    
+
                 const wait = new Promise(r => setTimeout(r, 3000));
                 await wait;
-    
+
                 const glueWindow = window.getGdWindow();
                 const windowContext = await glueWindow.getContext();
-    
+
                 expect(windowContext).to.eql(context);
             });
         });

--- a/e2e/tests/Workspaces/Parent/properties.spec.js
+++ b/e2e/tests/Workspaces/Parent/properties.spec.js
@@ -43,7 +43,7 @@ describe("properties: ", () => {
     };
     let workspace;
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         workspace = await glue.workspaces.createWorkspace(threeContainersConfig);
     });
 
@@ -175,7 +175,7 @@ describe("properties: ", () => {
         let workspace = undefined;
 
         before(async () => {
-            await Promise.all([glueReady, gtfReady]);
+            await coreReady;
             workspace = await glue.workspaces.createWorkspace(basicConfig);
         });
 
@@ -330,7 +330,7 @@ describe("properties: ", () => {
 
         let workspace = undefined;
         before(async () => {
-            await Promise.all([glueReady, gtfReady]);
+            await coreReady;
             await glue.workspaces.createWorkspace(config);
             workspace = await glue.workspaces.createWorkspace(config);
             await glue.workspaces.createWorkspace(config);
@@ -424,7 +424,7 @@ describe("properties: ", () => {
         let workspace = undefined;
 
         before(async () => {
-            await Promise.all([glueReady, gtfReady]);
+            await coreReady;
             workspace = await glue.workspaces.createWorkspace(basicConfig);
         });
 
@@ -484,7 +484,7 @@ describe("properties: ", () => {
         });
     });
 
-    describe("workspace: Should",()=>{
+    describe("workspace: Should", () => {
         const config = {
             children: [
                 {
@@ -524,38 +524,38 @@ describe("properties: ", () => {
                 newFrame: true
             }
         };
-    
+
         let workspace = undefined;
         before(async () => {
-            await Promise.all([glueReady, gtfReady]);
+            await coreReady;
             await glue.workspaces.createWorkspace(config);
             workspace = await glue.workspaces.createWorkspace(config);
             await glue.workspaces.createWorkspace(config);
         });
-    
+
         after(async () => {
             const frames = await glue.workspaces.getAllFrames();
             await Promise.all(frames.map((f) => f.close()));
         });
-    
+
         it("return the correct workspace when the parent is a row", () => {
             const row = workspace.getAllBoxes().find(p => p.type === "row");
             const resultWorkspace = row.workspace;
-    
+
             expect(resultWorkspace.id).to.eql(workspace.id);
         });
-    
+
         it("return the correct workspace when the parent is a column", () => {
             const column = workspace.getAllBoxes().find(p => p.type === "column");
             const resultWorkspace = column.workspace;
-    
+
             expect(resultWorkspace.id).to.eql(workspace.id);
         });
-    
+
         it("return the correct workspace when the parent is a group", () => {
             const group = workspace.getAllBoxes().find(p => p.type === "group");
             const resultWorkspace = group.workspace;
-    
+
             expect(resultWorkspace.id).to.eql(workspace.id);
         });
     });

--- a/e2e/tests/Workspaces/Parent/removeChild.spec.js
+++ b/e2e/tests/Workspaces/Parent/removeChild.spec.js
@@ -1,6 +1,6 @@
 describe("removeChild() Should", () => {
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
     afterEach(async () => {
         const frames = await glue.workspaces.getAllFrames();

--- a/e2e/tests/Workspaces/StartupArguments/context.spec.js
+++ b/e2e/tests/Workspaces/StartupArguments/context.spec.js
@@ -57,7 +57,7 @@ describe("Argument workspaceNames Should", () => {
     }
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         const workspaceOne = await glue.workspaces.createWorkspace(basicConfigOne);
         const workspaceTwo = await glue.workspaces.createWorkspace(basicConfigTwo);
 

--- a/e2e/tests/Workspaces/StartupArguments/emptyFrame.spec.js
+++ b/e2e/tests/Workspaces/StartupArguments/emptyFrame.spec.js
@@ -3,7 +3,7 @@ describe("Argument emptyFrame Should", () => {
     let windowsForClosing = [];
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(() => {

--- a/e2e/tests/Workspaces/StartupArguments/workspaceName.spec.js
+++ b/e2e/tests/Workspaces/StartupArguments/workspaceName.spec.js
@@ -34,7 +34,7 @@ describe("Argument workspaceName Should", () => {
     }
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         const workspace = await glue.workspaces.createWorkspace(basicConfig);
         await workspace.saveLayout(sampleLayoutName);
 

--- a/e2e/tests/Workspaces/StartupArguments/workspaceNames.spec.js
+++ b/e2e/tests/Workspaces/StartupArguments/workspaceNames.spec.js
@@ -53,7 +53,7 @@ describe("Argument workspaceNames Should", () => {
     }
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         const workspaceOne = await glue.workspaces.createWorkspace(basicConfigOne);
         const workspaceTwo = await glue.workspaces.createWorkspace(basicConfigTwo);
 

--- a/e2e/tests/Workspaces/Workspace/addColumn.spec.js
+++ b/e2e/tests/Workspaces/Workspace/addColumn.spec.js
@@ -14,7 +14,7 @@ describe('addColumn() Should ', function () {
     }
     let workspace = undefined;
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {
@@ -128,11 +128,11 @@ describe('addColumn() Should ', function () {
             const firstContext = {
                 first: true
             };
-    
+
             const secondContext = {
                 second: true
             };
-    
+
             const column = await workspace.addColumn({
                 children: [
                     {
@@ -147,17 +147,17 @@ describe('addColumn() Should ', function () {
                     }
                 ]
             });
-    
+
             await Promise.all(column.children.map((w) => w.forceLoad()));
             await workspace.refreshReference();
-    
+
             const wait = new Promise((r) => setTimeout(r, 3000));
             await wait;
-    
+
             await Promise.all(column.children.map(async (w, i) => {
                 const glueWin = w.getGdWindow();
                 const winContext = await glueWin.getContext();
-    
+
                 if (winContext.first) {
                     expect(winContext).to.eql(firstContext);
                 } else if (winContext.second) {

--- a/e2e/tests/Workspaces/Workspace/addGroup.spec.js
+++ b/e2e/tests/Workspaces/Workspace/addGroup.spec.js
@@ -15,7 +15,7 @@ describe('addGroup() Should ', function () {
     let workspace = undefined;
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {
@@ -50,7 +50,7 @@ describe('addGroup() Should ', function () {
         const secondContext = {
             second: true
         };
-        
+
         const group = await workspace.addGroup({
             children: [
                 {
@@ -128,11 +128,11 @@ describe('addGroup() Should ', function () {
             const firstContext = {
                 first: true
             };
-    
+
             const secondContext = {
                 second: true
             };
-            
+
             const group = await workspace.addGroup({
                 children: [
                     {
@@ -147,17 +147,17 @@ describe('addGroup() Should ', function () {
                     }
                 ]
             });
-    
+
             await Promise.all(group.children.map((w) => w.forceLoad()));
             await workspace.refreshReference();
-    
+
             const wait = new Promise((r) => setTimeout(r, 3000));
             await wait;
-    
+
             await Promise.all(group.children.map(async (w, i) => {
                 const glueWin = w.getGdWindow();
                 const winContext = await glueWin.getContext();
-    
+
                 if (winContext.first) {
                     expect(winContext).to.eql(firstContext);
                 } else if (winContext.second) {

--- a/e2e/tests/Workspaces/Workspace/addRow.spec.js
+++ b/e2e/tests/Workspaces/Workspace/addRow.spec.js
@@ -15,7 +15,7 @@ describe('addRow() Should ', function () {
     let workspace = undefined;
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {
@@ -50,7 +50,7 @@ describe('addRow() Should ', function () {
         const secondContext = {
             second: true
         };
-        
+
         const row = await workspace.addRow({
             children: [
                 {
@@ -127,11 +127,11 @@ describe('addRow() Should ', function () {
             const firstContext = {
                 first: true
             };
-    
+
             const secondContext = {
                 second: true
             };
-            
+
             const row = await workspace.addRow({
                 children: [
                     {
@@ -146,17 +146,17 @@ describe('addRow() Should ', function () {
                     }
                 ]
             });
-    
+
             await Promise.all(row.children.map((w) => w.forceLoad()));
             await workspace.refreshReference();
-    
+
             const wait = new Promise((r) => setTimeout(r, 3000));
             await wait;
-    
+
             await Promise.all(row.children.map(async (w, i) => {
                 const glueWin = w.getGdWindow();
                 const winContext = await glueWin.getContext();
-    
+
                 if (winContext.first) {
                     expect(winContext).to.eql(firstContext);
                 } else if (winContext.second) {

--- a/e2e/tests/Workspaces/Workspace/addWindow.spec.js
+++ b/e2e/tests/Workspaces/Workspace/addWindow.spec.js
@@ -15,7 +15,7 @@ describe('addWindow() Should ', function () {
     let workspace = undefined;
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {
@@ -98,16 +98,16 @@ describe('addWindow() Should ', function () {
                 appName: "dummyApp",
                 context
             });
-    
+
             await window.forceLoad();
             await workspace.refreshReference();
-    
+
             const wait = new Promise(r => setTimeout(r, 3000));
             await wait;
-    
+
             const glueWindow = window.getGdWindow();
             const windowContext = await glueWindow.getContext();
-    
+
             expect(windowContext).to.eql(context);
         });
 

--- a/e2e/tests/Workspaces/Workspace/bundleToColumn.spec.js
+++ b/e2e/tests/Workspaces/Workspace/bundleToColumn.spec.js
@@ -16,7 +16,7 @@ describe('bundleToColumn() Should ', function () {
     let workspace = undefined;
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/Workspace/bundleToRow.spec.js
+++ b/e2e/tests/Workspaces/Workspace/bundleToRow.spec.js
@@ -16,7 +16,7 @@ describe('bundleToRow() Should ', function () {
     let workspace = undefined;
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/Workspace/close.spec.js
+++ b/e2e/tests/Workspaces/Workspace/close.spec.js
@@ -15,7 +15,7 @@ describe('close() Should ', function () {
     let workspace = undefined;
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/Workspace/getAllColumns.spec.js
+++ b/e2e/tests/Workspaces/Workspace/getAllColumns.spec.js
@@ -39,7 +39,7 @@ describe("getAllColumns() Should", () => {
     let workspace = undefined;
     //TODO add predicate tests
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         workspace = await glue.workspaces.createWorkspace(basicConfig);
     });
 
@@ -55,7 +55,7 @@ describe("getAllColumns() Should", () => {
     });
 
     // Not focused workspace
-    it("return all columns when the workspace is not focused", async() => {
+    it("return all columns when the workspace is not focused", async () => {
         await glue.workspaces.createWorkspace(basicConfig);
         const columns = workspace.getAllColumns();
 

--- a/e2e/tests/Workspaces/Workspace/getAllGroups.spec.js
+++ b/e2e/tests/Workspaces/Workspace/getAllGroups.spec.js
@@ -43,7 +43,7 @@ describe("getAllGroups() Should", () => {
     let workspace = undefined;
     //TODO add predicate tests
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         workspace = await glue.workspaces.createWorkspace(basicConfig);
     });
 
@@ -59,7 +59,7 @@ describe("getAllGroups() Should", () => {
     });
 
     // Not focused workspace
-    it("return all groups when the workspace is not focused", async() => {
+    it("return all groups when the workspace is not focused", async () => {
         await glue.workspaces.createWorkspace(basicConfig);
         const groups = workspace.getAllGroups();
 

--- a/e2e/tests/Workspaces/Workspace/getAllParents.spec.js
+++ b/e2e/tests/Workspaces/Workspace/getAllParents.spec.js
@@ -39,7 +39,7 @@ describe("getAllBoxes() Should", () => {
     let workspace = undefined;
     //TODO add predicate tests
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         workspace = await glue.workspaces.createWorkspace(basicConfig);
     });
 

--- a/e2e/tests/Workspaces/Workspace/getAllRows.spec.js
+++ b/e2e/tests/Workspaces/Workspace/getAllRows.spec.js
@@ -39,7 +39,7 @@ describe("getAllRows() Should", () => {
     let workspace = undefined;
     //TODO add predicate tests
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         workspace = await glue.workspaces.createWorkspace(basicConfig);
     });
 
@@ -55,7 +55,7 @@ describe("getAllRows() Should", () => {
     });
 
     // Not focused workspae
-    it("return all rows when the workspace is not focused",async () => {
+    it("return all rows when the workspace is not focused", async () => {
         await glue.workspaces.createWorkspace(basicConfig);
         const rows = workspace.getAllRows();
 

--- a/e2e/tests/Workspaces/Workspace/getAllWindows.spec.js
+++ b/e2e/tests/Workspaces/Workspace/getAllWindows.spec.js
@@ -15,7 +15,7 @@ describe('getAllWindows() Should ', function () {
     let workspace = undefined;
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/Workspace/getColumn.spec.js
+++ b/e2e/tests/Workspaces/Workspace/getColumn.spec.js
@@ -39,7 +39,7 @@ describe("getColumn() Should", () => {
     let workspace = undefined;
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         workspace = await glue.workspaces.createWorkspace(basicConfig);
     });
 

--- a/e2e/tests/Workspaces/Workspace/getGroup.spec.js
+++ b/e2e/tests/Workspaces/Workspace/getGroup.spec.js
@@ -43,7 +43,7 @@ describe("getGroup() Should", () => {
     let workspace = undefined;
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         workspace = await glue.workspaces.createWorkspace(basicConfig);
     });
 

--- a/e2e/tests/Workspaces/Workspace/getParent.spec.js
+++ b/e2e/tests/Workspaces/Workspace/getParent.spec.js
@@ -39,7 +39,7 @@ describe("getBox() Should", () => {
     let workspace = undefined;
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         workspace = await glue.workspaces.createWorkspace(basicConfig);
     });
 

--- a/e2e/tests/Workspaces/Workspace/getRow.spec.js
+++ b/e2e/tests/Workspaces/Workspace/getRow.spec.js
@@ -39,7 +39,7 @@ describe("getRow() Should", () => {
     let workspace = undefined;
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         workspace = await glue.workspaces.createWorkspace(basicConfig);
     });
 

--- a/e2e/tests/Workspaces/Workspace/getWindow.spec.js
+++ b/e2e/tests/Workspaces/Workspace/getWindow.spec.js
@@ -38,7 +38,7 @@ describe("getWindow() Should", () => {
 
     let workspace = undefined;
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         workspace = await glue.workspaces.createWorkspace(basicConfig);
     });
 

--- a/e2e/tests/Workspaces/Workspace/properties.spec.js
+++ b/e2e/tests/Workspaces/Workspace/properties.spec.js
@@ -43,7 +43,7 @@ describe("properties: ", () => {
     let workspace;
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         workspace = await glue.workspaces.createWorkspace(threeContainersConfig);
     });
 
@@ -249,7 +249,7 @@ describe("properties: ", () => {
         let workspace = undefined;
 
         before(async () => {
-            await Promise.all([glueReady, gtfReady]);
+            await coreReady;
             workspace = await glue.workspaces.createWorkspace(basicConfig);
         });
 
@@ -295,7 +295,7 @@ describe("properties: ", () => {
 
 
         before(() => {
-            return Promise.all([glueReady, gtfReady]);
+            return coreReady;
         });
 
         afterEach(async () => {

--- a/e2e/tests/Workspaces/Workspace/refreshReference.spec.js
+++ b/e2e/tests/Workspaces/Workspace/refreshReference.spec.js
@@ -14,9 +14,9 @@ describe('refreshReference() Should ', function () {
     }
     let workspace = undefined;
 
-    
+
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/Workspace/saveLayout.spec.js
+++ b/e2e/tests/Workspaces/Workspace/saveLayout.spec.js
@@ -15,13 +15,13 @@ describe('saveLayout() Should ', function () {
     let workspace = undefined;
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {
         workspace = await glue.workspaces.createWorkspace(basicConfig);
     });
-    
+
     afterEach(async () => {
         const summaries = await glue.workspaces.layouts.getSummaries();
 

--- a/e2e/tests/Workspaces/Workspace/setTitle.spec.js
+++ b/e2e/tests/Workspaces/Workspace/setTitle.spec.js
@@ -15,7 +15,7 @@ describe('setTitle() Should ', function () {
     let workspace = undefined;
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/Workspace/snapshot.spec.js
+++ b/e2e/tests/Workspaces/Workspace/snapshot.spec.js
@@ -15,7 +15,7 @@ describe('snapshot() Should ', function () {
     let workspace = undefined;
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/WorkspaceWindow/close.spec.js
+++ b/e2e/tests/Workspaces/WorkspaceWindow/close.spec.js
@@ -17,7 +17,7 @@ describe("close() Should", () => {
     let workspace = undefined;
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
 
     });
 

--- a/e2e/tests/Workspaces/WorkspaceWindow/eject.spec.js
+++ b/e2e/tests/Workspaces/WorkspaceWindow/eject.spec.js
@@ -18,7 +18,7 @@ describe("eject() Should", () => {
     let windowsForClosing = [];
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
     });
 
     beforeEach(async () => {
@@ -120,7 +120,7 @@ describe("eject() Should", () => {
         };
         const ejectedWindow = await waitForWindowByName(window.appName);
         const wait = new Promise(r => setTimeout(r, 3000));
-        
+
         await wait;
 
         const contextAfterEject = await ejectedWindow.getContext();

--- a/e2e/tests/Workspaces/WorkspaceWindow/forceLoad.spec.js
+++ b/e2e/tests/Workspaces/WorkspaceWindow/forceLoad.spec.js
@@ -17,7 +17,7 @@ describe("forceLoad() Should", () => {
     let workspace = undefined;
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/WorkspaceWindow/getGdWindow.spec.js
+++ b/e2e/tests/Workspaces/WorkspaceWindow/getGdWindow.spec.js
@@ -17,7 +17,7 @@ describe("getGdWindow() Should", () => {
     let workspace = undefined;
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/WorkspaceWindow/maximize.spec.js
+++ b/e2e/tests/Workspaces/WorkspaceWindow/maximize.spec.js
@@ -18,7 +18,7 @@ describe("maximize() Should", () => {
     let window = undefined;
 
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/WorkspaceWindow/moveTo.spec.js
+++ b/e2e/tests/Workspaces/WorkspaceWindow/moveTo.spec.js
@@ -84,7 +84,7 @@ describe("moveTo() Should", async () => {
     }
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
     });
 
     afterEach(async () => {

--- a/e2e/tests/Workspaces/WorkspaceWindow/properties.spec.js
+++ b/e2e/tests/Workspaces/WorkspaceWindow/properties.spec.js
@@ -43,7 +43,7 @@ describe("properties: ", () => {
     let workspace;
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
         workspace = await glue.workspaces.createWorkspace(threeContainersConfig);
     });
 
@@ -185,7 +185,7 @@ describe("properties: ", () => {
             expect(typeof window.focused).to.eql("boolean");
         });
     });
-    
+
     describe("appName: ", () => {
         it(`Should be correct`, () => {
             const window = workspace.getAllWindows()[0];

--- a/e2e/tests/Workspaces/WorkspaceWindow/restore.spec.js
+++ b/e2e/tests/Workspaces/WorkspaceWindow/restore.spec.js
@@ -17,7 +17,7 @@ describe("restore() Should", () => {
     let workspace = undefined;
     let window = undefined;
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/Workspaces/WorkspaceWindow/setTitle.spec.js
+++ b/e2e/tests/Workspaces/WorkspaceWindow/setTitle.spec.js
@@ -18,7 +18,7 @@ describe("setTitle() Should", () => {
     let workspace = undefined;
 
     before(async () => {
-        await Promise.all([glueReady, gtfReady]);
+        await coreReady;
     });
 
     beforeEach(async () => {

--- a/e2e/tests/channels/API/add.spec.js
+++ b/e2e/tests/channels/API/add.spec.js
@@ -1,6 +1,6 @@
 describe('add()', () => {
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     it('Should reject with an error when info isn\'t of type object.', async () => {

--- a/e2e/tests/channels/API/all.spec.js
+++ b/e2e/tests/channels/API/all.spec.js
@@ -1,6 +1,6 @@
 describe('all()', () => {
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     it('Should return an array with the correct channel names.', async () => {

--- a/e2e/tests/channels/API/changed.spec.js
+++ b/e2e/tests/channels/API/changed.spec.js
@@ -1,6 +1,6 @@
 describe('changed()', () => {
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     afterEach(() => {

--- a/e2e/tests/channels/API/current.spec.js
+++ b/e2e/tests/channels/API/current.spec.js
@@ -1,6 +1,6 @@
 describe('current()', () => {
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     afterEach(() => {

--- a/e2e/tests/channels/API/get.spec.js
+++ b/e2e/tests/channels/API/get.spec.js
@@ -1,6 +1,6 @@
 describe('get()', () => {
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     afterEach(async () => {

--- a/e2e/tests/channels/API/join.spec.js
+++ b/e2e/tests/channels/API/join.spec.js
@@ -1,6 +1,6 @@
 describe('join()', () => {
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     afterEach(() => {

--- a/e2e/tests/channels/API/leave.spec.js
+++ b/e2e/tests/channels/API/leave.spec.js
@@ -1,6 +1,6 @@
 describe('leave()', () => {
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     it('Should leave the current channel.', async () => {

--- a/e2e/tests/channels/API/list.spec.js
+++ b/e2e/tests/channels/API/list.spec.js
@@ -1,6 +1,6 @@
 describe('list()', () => {
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     it('Should return an array with the correct channel contexts added by us and by another party.', async () => {

--- a/e2e/tests/channels/API/my.spec.js
+++ b/e2e/tests/channels/API/my.spec.js
@@ -1,6 +1,6 @@
 describe('my()', () => {
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     afterEach(() => {

--- a/e2e/tests/channels/API/onChanged.spec.js
+++ b/e2e/tests/channels/API/onChanged.spec.js
@@ -1,6 +1,6 @@
 describe('onChanged()', () => {
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     it('Should throw an error when callback isn\'t of type function.', () => {

--- a/e2e/tests/channels/API/publish.spec.js
+++ b/e2e/tests/channels/API/publish.spec.js
@@ -1,6 +1,6 @@
 describe('publish()', () => {
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     afterEach(async () => {

--- a/e2e/tests/channels/API/subscribe.spec.js
+++ b/e2e/tests/channels/API/subscribe.spec.js
@@ -1,6 +1,6 @@
 describe('subscribe()', () => {
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     afterEach(async () => {

--- a/e2e/tests/channels/API/subscribeFor.spec.js
+++ b/e2e/tests/channels/API/subscribeFor.spec.js
@@ -1,6 +1,6 @@
 describe('subscribeFor()', () => {
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     afterEach(async () => {

--- a/e2e/tests/channels/initialization.spec.js
+++ b/e2e/tests/channels/initialization.spec.js
@@ -1,6 +1,6 @@
 describe('initialization', () => {
     before(() => {
-        return Promise.all([glueReady, gtfReady]);
+        return coreReady;
     });
 
     const channelsAPIMethods = [

--- a/packages/fdc3/src/channels/channel.ts
+++ b/packages/fdc3/src/channels/channel.ts
@@ -1,6 +1,7 @@
 import { FDC3 } from "../../types";
 import { Glue42 } from "@glue42/desktop";
 import { WindowType } from "../windowtype";
+import { newSubscribe } from "../utils";
 
 export class SystemChannel implements FDC3.Channel {
     id: string;
@@ -36,14 +37,7 @@ export class SystemChannel implements FDC3.Channel {
         const contextType = arguments.length === 2 && contextTypeInput;
         const handler = arguments.length === 2 ? handlerInput : contextTypeInput;
 
-        let isReplay = true;
-
-        const subIgnoringReplay = (data: any): void => {
-            if (isReplay) {
-                isReplay = false;
-                return;
-            }
-
+        const subHandler = (data: any): void => {
             if (contextType) {
                 if (data?.type === contextType) {
                     handler(data);
@@ -53,7 +47,7 @@ export class SystemChannel implements FDC3.Channel {
             }
         };
 
-        const unsubPromise = (window as WindowType).glue.channels.subscribeFor(this.id, subIgnoringReplay);
+        const unsubPromise = (window as WindowType).glue.channels.subscribeFor(this.id, subHandler);
 
         return {
             unsubscribe(): void {
@@ -101,7 +95,7 @@ export class AppChannel implements FDC3.Channel {
         const contextType = arguments.length === 2 && contextTypeInput;
         const handler = arguments.length === 2 ? handlerInput : contextTypeInput;
 
-        const callback = (data: any): void => {
+        const subHandler = (data: any): void => {
             if (contextType) {
                 if (data?.type === contextType) {
                     handler(data);
@@ -111,7 +105,7 @@ export class AppChannel implements FDC3.Channel {
             }
         };
 
-        const unsubPromise = (window as WindowType).glue.contexts.subscribe(this.id, callback);
+        const unsubPromise = newSubscribe(this.id, subHandler);
 
         return {
             unsubscribe: (): void => {

--- a/packages/fdc3/src/main.ts
+++ b/packages/fdc3/src/main.ts
@@ -1,7 +1,7 @@
 import createDesktopAgent from "./agent";
 import Glue, { Glue42 } from "@glue42/desktop";
 import GlueWebFactory from "@glue42/web";
-import { decorateContextApi, getChannelsList, isEmptyObject, isGlue42Core } from "./utils";
+import { getChannelsList, isEmptyObject, isGlue42Core } from "./utils";
 import { version } from "../package.json";
 import { FDC3 } from "../types";
 import { WindowType } from "./windowtype";
@@ -37,8 +37,7 @@ const patchSharedContexts = (): Promise<void> => {
 const setupGlue = (clientGlueConfig?: Glue42.Config): void => {
     if (isGlue42Core) {
         (window as WindowType).gluePromise = GlueWebFactory(defaultGlueConfig)
-            .then((g) => {
-                const glue = decorateContextApi(g);
+            .then((glue) => {
                 (window as WindowType).glue = glue;
 
                 return patchSharedContexts();
@@ -68,8 +67,7 @@ const setupGlue = (clientGlueConfig?: Glue42.Config): void => {
 
                 return GlueFactory(clientGlueConfig || defaultGlueConfig);
             })
-            .then((g) => {
-                const glue = decorateContextApi(g);
+            .then((glue) => {
                 (window as WindowType).glue = glue;
 
                 return patchSharedContexts();


### PR DESCRIPTION
Fix a bug where `tryLeaveSystem()` was not awaited
Remove the subscribe's initial replay ignore
Update the Channels e2e tests to use the coreReady promise