### PR TITLE
Add input validation to the @glue42/core's Contexts API

### DIFF
--- a/docs/core/04_core-concepts/03_glue42-client/03_react/react.md
+++ b/docs/core/04_core-concepts/03_glue42-client/03_react/react.md
@@ -111,7 +111,7 @@ ReactDOM.render(
 
 - #### useGlueInit()
 
-You can also initialize the [**Glue42 Web**](../../../../reference/core/latest/glue42%20web/index.html) library with the `useGlueInit()` hook. Below is an example of conditional rendering of a component based on whether the Glue42 Web API is available or not. 
+You can also initialize the [**Glue42 Web**](../../../../reference/core/latest/glue42%20web/index.html) library with the `useGlueInit()` hook. Below is an example of conditional rendering of a component based on whether the Glue42 Web API is available or not.
 
 ```javascript
 import GlueWeb from "@glue42/web";
@@ -137,7 +137,7 @@ Remember that when you initialize the Glue42 Web library with the `useGlueInit()
 
 ### Consuming Glue42 Web APIs
 
-After the [**Glue42 Web**](../../../../reference/core/latest/glue42%20web/index.html) library has been successfully initialized, you can access the Glue42 Web APIs with the built-in React hook `useContext()` and passing `GlueContext` as its argument, or with the `useGlue()` hook. 
+After the [**Glue42 Web**](../../../../reference/core/latest/glue42%20web/index.html) library has been successfully initialized, you can access the Glue42 Web APIs with the built-in React hook `useContext()` and passing `GlueContext` as its argument, or with the `useGlue()` hook.
 
 **Note** that this library is just a thin wrapper designed to work with both `@glue42/web` and `@glue42/desktop`. For that reason, if you are using react with typescript you should type cast the initialized glue object to the appropriate type, because the default type is `Glue42Web.API | Glue42.Glue`;
 
@@ -151,7 +151,7 @@ import { GlueContext } from "@glue42/react-hooks";
 
 const App = () => {
     const [context, setContext] = useState({});
-    // Access the Glue42 Web APIs by using the `glue` object 
+    // Access the Glue42 Web APIs by using the `glue` object
     // assigned as a value to `GlueContext` by the `GlueProvider` component.
     const glue = useContext(GlueContext);
 
@@ -203,7 +203,7 @@ const App = () => {
 export default App;
 ```
 
-This is an example of using the [Interop](../../../../reference/core/latest/interop/index.html) API to get the window title through an already registered Interop method:  
+This is an example of using the [Interop](../../../../reference/core/latest/interop/index.html) API to get the window title through an already registered Interop method:
 
 ```javascript
 import { useGlue } from "@glue42/react-hooks";
@@ -233,13 +233,13 @@ export default App;
 
 ### Testing
 
-You can use your own factory function for initializing the [**Glue42 Web**](../../../../reference/core/latest/glue42%20web/index.html) library. This is useful in Jest/Enzyme tests when you want to mock the Glue42 library: 
+You can use your own factory function for initializing the [**Glue42 Web**](../../../../reference/core/latest/glue42%20web/index.html) library. This is useful in Jest/Enzyme tests when you want to mock the Glue42 library:
 
 ```javascript
 //index.js
 import "glue42/web";
 import { mount } from "enzyme";
-import { GlueProvider } from "glue42/react-hooks";
+import { GlueProvider } from "@glue42/react-hooks";
 
 // Define a factory function which will mock the Glue42 Web library.
 const glueFactory = () => {

--- a/e2e/tests/channels/API/join.spec.js
+++ b/e2e/tests/channels/API/join.spec.js
@@ -60,4 +60,23 @@ describe('join()', () => {
         expect(currentChannel).to.not.equal(firstChannelName);
         expect(currentChannel).to.equal(secondChannelName);
     });
+
+    it('Should set the current channel before calling any subscribe callbacks.', async () => {
+        const [channelName] = await gtf.getChannelNames();
+
+        const subscribeCurrentChannelPromise = new Promise((resolve) => {
+            const unsunbscribe = glue.channels.subscribe(() => {
+                unsunbscribe();
+
+                // The current channel.
+                resolve(glue.channels.current());
+            });
+        });
+
+        // Join the channel.
+        await glue.channels.join(channelName);
+
+        const currentChannel = await subscribeCurrentChannelPromise;
+        expect(currentChannel).to.equal(channelName);
+    });
 });

--- a/packages/web/src/channels/main.ts
+++ b/packages/web/src/channels/main.ts
@@ -116,8 +116,8 @@ export class Channels implements Glue42Web.Channels.API {
             await channelExistsPromise;
         }
 
-        await this.shared.switchChannel(name);
         this.currentContext = name;
+        await this.shared.switchChannel(name);
         this.registry.execute(this.changedKey, name);
     }
 

--- a/packages/web/web.d.ts
+++ b/packages/web/web.d.ts
@@ -345,7 +345,7 @@ export namespace Glue42Web {
 
         export interface CreateOptions extends Settings {
             /** Required. The URL of the app to be loaded in the new window */
-            url: string;
+            url?: string;
         }
 
         export type RelativeDirection = "top" | "left" | "right" | "bottom";
@@ -390,7 +390,7 @@ export namespace Glue42Web {
          * @docmenuorder 1
          */
         export interface API {
-            
+
             /**
              * Fetches a saved layout or returns undefined if a layout with the provided name and type does not exist.
              * @param type Type of the layout to fetch.
@@ -403,13 +403,13 @@ export namespace Glue42Web {
              * @param type Type of the layouts to fetch.
              */
             getAll?(type: LayoutType): Promise<LayoutSummary[]>;
-        
+
             /**
              * Returns all layouts from the provided type.
              * @param type Type of the layouts to export.
              */
             export(layoutType?: LayoutType): Promise<Layout[]>;
-        
+
             /**
              * Stores a full layout.
              * @param layout The layout object to be stored.


### PR DESCRIPTION
Fix an issue inside the Channels API where join fired the subscribe callbacks before the new current channel had been set and add a test that covers the case
Make the url of the CreateOptions type optional
Fix a typo inside the Glue42 Core React documentation