### PR TITLE
Implement an Intents API (TODO: Tests, Typings explanation, Documentation, Live examples and Tutorial)

### DIFF
--- a/packages/fdc3/package-lock.json
+++ b/packages/fdc3/package-lock.json
@@ -31,9 +31,9 @@
             }
         },
         "@glue42/core": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/@glue42/core/-/core-5.1.2.tgz",
-            "integrity": "sha512-JfeP+O5ikhyg1/XGHApqf4DtA61nzH0EB3CNmuNYMmSvQ+KgR9QqBC9JMC+GM7NWecqboWHlQ+HmdZFAdpNXSw==",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@glue42/core/-/core-5.2.3.tgz",
+            "integrity": "sha512-4ZstQ24zRWVYRoPBjiPTWVBWhR+u6hTVlzP88IC5o+k83syr6kNMFWpzsVNSwogj2LXA+wc99JOcSd35nEKEpw==",
             "requires": {
                 "callback-registry": "^2.6.0",
                 "shortid": "^2.2.6",
@@ -41,13 +41,36 @@
             }
         },
         "@glue42/desktop": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/@glue42/desktop/-/desktop-5.1.4.tgz",
-            "integrity": "sha512-b2iGe7lQ0SqoI2vd8cHEEEfP1eDRC/EiDVFsPdajApBOgJy1VKx4bYPGXRv7wFpNfmgtqLs4sDirUcqugqfERg==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/@glue42/desktop/-/desktop-5.2.1.tgz",
+            "integrity": "sha512-aiD+BJBv9Ue1SqhkqkxNaC4WCQMaybYvizvOehmnWM7m71J967vG92xWxvHV/faiePffj6KvkT/nvm3OwBZSmA==",
             "requires": {
-                "@glue42/core": "^5.0.7",
+                "@glue42/core": "^5.2.3",
+                "@glue42/workspaces-api": "^1.0.0",
                 "callback-registry": "^2.5.2",
                 "shortid": "2.2.8"
+            }
+        },
+        "@glue42/workspaces-api": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@glue42/workspaces-api/-/workspaces-api-1.0.4.tgz",
+            "integrity": "sha512-SqUEzHOJ/oKnDe2xtAIOzHi6nvSsgSCH7GHSQLk3DA0Nzom3vXs1leEZhlZyjfqG6zi4wmjsVTY2N1eP7OJiIA==",
+            "requires": {
+                "@glue42/core": "^5.2.3",
+                "callback-registry": "^2.5.2",
+                "decoder-validate": "0.0.1"
+            },
+            "dependencies": {
+                "@glue42/core": {
+                    "version": "5.2.3",
+                    "resolved": "https://registry.npmjs.org/@glue42/core/-/core-5.2.3.tgz",
+                    "integrity": "sha512-4ZstQ24zRWVYRoPBjiPTWVBWhR+u6hTVlzP88IC5o+k83syr6kNMFWpzsVNSwogj2LXA+wc99JOcSd35nEKEpw==",
+                    "requires": {
+                        "callback-registry": "^2.6.0",
+                        "shortid": "^2.2.6",
+                        "ws": "7.1.2"
+                    }
+                }
             }
         },
         "@rollup/plugin-commonjs": {
@@ -211,6 +234,11 @@
             "resolved": "https://repo.tick42.com:443/api/npm/tick42-npm/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
+        },
+        "decoder-validate": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/decoder-validate/-/decoder-validate-0.0.1.tgz",
+            "integrity": "sha512-uwHIDbUJSSLGrLe0ZGNeF9b8YuDvRucBC7GE+a9Ot19Q2oQJkAxCDFS0zZUrTbFaRGhN/Yira2aftI10EPBxWQ=="
         },
         "deep-freeze": {
             "version": "0.0.1",

--- a/packages/fdc3/package.json
+++ b/packages/fdc3/package.json
@@ -28,7 +28,7 @@
     },
     "license": "MIT",
     "dependencies": {
-        "@glue42/desktop": "^5.1.4",
+        "@glue42/desktop": "^5.2.1",
         "@glue42/web": "^1.4.4"
     },
     "devDependencies": {

--- a/packages/fdc3/src/agent.ts
+++ b/packages/fdc3/src/agent.ts
@@ -1,17 +1,14 @@
 import { FDC3 } from "../types";
 import { Glue42 } from "@glue42/desktop";
-import { Glue42Web } from "@glue42/web";
-import createChannelsApi from "./channels/channels";
-import { isGlue42Core } from "./utils";
+import createChannelsAgent from "./channels/channels";
 import { WindowType } from "./windowtype";
-
-const GLUE42_CORE_FDC3_INTENTS_METHOD_PREFIX = "Tick42.FDC3.Intents.";
 
 const convertGlue42IntentToFDC3AppIntent = (glueIntent: Glue42.Intents.Intent): FDC3.AppIntent => {
     const { name, handlers } = glueIntent;
 
     const appIntent: FDC3.AppIntent = {
-        intent: { name, displayName: handlers[0].displayName },
+        // Issue with the FDC3 specification: there are multiple displayNames.
+        intent: { name, displayName: handlers[0].displayName || "" },
         apps: glueIntent.handlers.map((handler) => {
             const app = (window as WindowType).glue.appManager.application(handler.applicationName);
 
@@ -29,93 +26,7 @@ const convertGlue42IntentToFDC3AppIntent = (glueIntent: Glue42.Intents.Intent): 
     return appIntent;
 };
 
-const getGlue42CoreIntents = async (): Promise<{ intent: FDC3.Intent | undefined; apps: Glue42Web.AppManager.Application[] }[]> => {
-    const apps = await ((window as WindowType).glue as Glue42Web.API).appManager.applications();
-    const appIntents: { intent: FDC3.Intent; app: Glue42Web.AppManager.Application }[] = apps.flatMap((app: Glue42Web.AppManager.Application) => {
-        return (app.userProperties.intents?.map((intent: FDC3.Intent) => {
-            return {
-                intent,
-                app: {
-                    name: app.name,
-                    title: app.title,
-                    tooltip: app.userProperties.tooltip,
-                    description: app.userProperties.description,
-                    icons: app.userProperties.icons,
-                    images: app.userProperties.images
-                }
-            };
-        }) || []);
-    });
-    const intentNames = Array.from(new Set(appIntents.map((appIntent) => {
-        return appIntent.intent.name;
-    })));
-    const intents = intentNames.map((intentName) => {
-        return {
-            intent: appIntents.find((appIntent) => {
-                return appIntent.intent.name === intentName;
-            })?.intent,
-            apps: [...appIntents.filter((appIntent) => {
-                return appIntent.intent.name === intentName;
-            }).map((appIntent) => {
-                return appIntent.app;
-            })]
-        };
-    });
-
-    return intents;
-};
-
-const getGlue42CoreIntentsByContext = async (context: FDC3.Context): Promise<{ intent: FDC3.Intent; app: Glue42Web.AppManager.Application }[]> => {
-    const apps = await ((window as WindowType).glue as Glue42Web.API).appManager.applications();
-    const appIntents: { intent: FDC3.Intent; app: Glue42Web.AppManager.Application }[] = apps.flatMap((app: Glue42Web.AppManager.Application) => {
-        return (app.userProperties.intents?.map((intent: FDC3.Intent) => {
-            return {
-                intent,
-                app: {
-                    name: app.name,
-                    title: app.title,
-                    tooltip: app.userProperties.tooltip,
-                    description: app.userProperties.description,
-                    icons: app.userProperties.icons,
-                    images: app.userProperties.images
-                }
-            };
-        }) || []);
-    });
-
-    const appIntentsForContext = appIntents.filter((appIntent) => {
-        return appIntent.intent.contexts?.includes(context.type);
-    });
-
-    return appIntentsForContext;
-};
-
-const startAppAndWaitForIntentMethod = async (app: Glue42.AppManager.Application | Glue42Web.AppManager.Application, intent: string): Promise<Glue42Web.Interop.Instance> => {
-    try {
-        await app.start();
-    } catch (error) {
-        // `start()` is expected to reject as the started application needs to pass in application name to `GlueWeb()`
-    }
-
-    // Wait for the newly started application to call addIntentListener.
-    const methodAddedPromise = new Promise<Glue42Web.Interop.Instance>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-            reject(`Raise intent ${intent} target ${app.name} application did not call addIntentListener after being started.`);
-        }, 3000);
-
-        const unsub = (window as WindowType).glue.interop.serverMethodAdded((info) => {
-            if (info.method.name === `${GLUE42_CORE_FDC3_INTENTS_METHOD_PREFIX}${intent}`) {
-                clearTimeout(timeout);
-                unsub();
-                resolve(info.server);
-            }
-        });
-    });
-
-    return methodAddedPromise;
-};
-
-const createCoreDesktopAgent = (): Partial<FDC3.DesktopAgent> => {
+const createIntentsAgent = (): Partial<FDC3.DesktopAgent> => {
     const open = async (name: string, context?: FDC3.Context): Promise<void> => {
         const app = (window as WindowType).glue.appManager.application(name);
         if (!app) {
@@ -129,214 +40,99 @@ const createCoreDesktopAgent = (): Partial<FDC3.DesktopAgent> => {
         }
     };
 
+    const findIntent = async (intent: string, context?: FDC3.Context): Promise<FDC3.AppIntent> => {
+        if (typeof intent !== "string") {
+            throw new Error("Please provide the intent as a string!");
+        }
+        if (typeof context !== "undefined" && typeof context.type !== "string") {
+            throw new Error("Please provide the context.type as a string!");
+        }
+
+        const glueIntents = await (window as WindowType).glue.intents.find({ name: intent, contextType: context?.type });
+
+        if (typeof glueIntents !== "undefined" && glueIntents.length === 0) {
+            throw new Error(FDC3.ResolveError.NoAppsFound);
+        }
+
+        // We will receive only one intent as they are grouped by name.
+        return convertGlue42IntentToFDC3AppIntent(glueIntents[0]);
+    };
+
+    const findIntentsByContext = async (context: FDC3.Context): Promise<FDC3.AppIntent[]> => {
+        if (typeof context !== "undefined" && typeof context.type !== "string") {
+            throw new Error("Please provide the context.type as a string!");
+        }
+
+        const glueIntents = await (window as WindowType).glue.intents.find({ contextType: context.type });
+
+        if (typeof glueIntents !== "undefined" && glueIntents.length === 0) {
+            throw new Error(FDC3.ResolveError.NoAppsFound);
+        }
+
+        return glueIntents.map((glueIntent) => convertGlue42IntentToFDC3AppIntent(glueIntent));
+    };
+
+    const raiseIntent = async (intent: string, context: FDC3.Context, target?: string): Promise<FDC3.IntentResolution> => {
+        if (typeof intent !== "string") {
+            throw new Error("Please provide the intent as a string!");
+        }
+        if (typeof context !== "undefined" && typeof context.type !== "string") {
+            throw new Error("Please provide the context.type as a string!");
+        }
+        if (typeof target !== "undefined" && typeof target !== "string") {
+            throw new Error("Please provide the target as a string!");
+        }
+
+        // target not provided => reuse (@glue42/web takes care of starting a new instance if there isn't a running one)
+        // target provided; no running instance => target app
+        // target provided; there is a running instance => target instance
+        let glueTarget: "startNew" | "reuse" | { app?: string; instance?: string } = "reuse";
+        if (typeof target !== "undefined") {
+            const app = (window as WindowType).glue.appManager.application(target);
+            if (typeof app === "undefined") {
+                throw new Error(`Application ${target} not found.`);
+            }
+            const appInstances = app.instances;
+            if (appInstances.length === 0) {
+                glueTarget = { app: target };
+            } else {
+                // Issue with the FDC3 specification: there is no instance targeting.
+                glueTarget = { instance: appInstances[0].id };
+            }
+        }
+
+        const glueIntentResult = await (window as WindowType).glue.intents.raise({ intent, context, target: glueTarget });
+
+        return {
+            source: glueIntentResult.handler.applicationName,
+            version: "1.0.0",
+            data: glueIntentResult.result
+        };
+    };
+
+    const addIntentListener = (intent: string, handler: (context: FDC3.Context) => void): FDC3.Listener => {
+        if (typeof intent !== "string") {
+            throw new Error("Please provide the intent as a string!");
+        }
+        if (typeof handler !== "function") {
+            throw new Error("Please provide the handler as a function!");
+        }
+        const unsub = {
+            unsubscribe: () => console.error("Could not unsubscribe!")
+        };
+
+        (window as WindowType).gluePromise.then(() => {
+            unsub.unsubscribe = (window as WindowType).glue.intents.addIntentListener(intent, handler as (context: object) => void).unsubscribe;
+        });
+
+        return unsub;
+    };
+
     return {
         open: async (...props): Promise<void> => {
             await (window as WindowType).gluePromise;
             return open(...props);
-        }
-    };
-};
-
-const createGlue42CoreDesktopAgent = (): Partial<FDC3.DesktopAgent> => {
-    const findIntent = async (intent: string, context?: FDC3.Context): Promise<FDC3.AppIntent> => {
-        const glueIntents = await getGlue42CoreIntents();
-
-        const foundIntent = glueIntents.find((glueIntent) => {
-            if (context) {
-                return glueIntent.intent?.name === intent && glueIntent.intent.contexts?.includes(context.type);
-            } else {
-                return glueIntent.intent?.name === intent;
-            }
-        });
-
-        if (!foundIntent) {
-            throw new Error(FDC3.ResolveError.NoAppsFound);
-        }
-
-        return foundIntent as FDC3.AppIntent;
-    };
-
-    const findIntentsByContext = async (context: FDC3.Context): Promise<FDC3.AppIntent[]> => {
-        if (!context.type) {
-            throw new Error("Only filtering by context.type is supported.");
-        }
-
-        const intents = await getGlue42CoreIntentsByContext(context);
-
-        return intents.map((intent) => ({
-            intent: intent.intent,
-            apps: [intent.app]
-        })) as FDC3.AppIntent[];
-    };
-
-    const raiseIntent = async (intent: string, context: FDC3.Context, target?: string): Promise<FDC3.IntentResolution> => {
-        let instancesToTarget;
-        let invocationResult;
-        const methodName = `${GLUE42_CORE_FDC3_INTENTS_METHOD_PREFIX}${intent}`;
-
-        if (target) {
-            const appTarget = ((window as WindowType).glue as Glue42Web.API).appManager.application(target);
-
-            if (!appTarget) {
-                throw new Error(FDC3.OpenError.AppNotFound);
-            }
-
-            instancesToTarget = ((window as WindowType).glue as Glue42Web.API).appManager.instances().filter((appInstance) => {
-                return appInstance.application.name === target;
-            }).map((appInstance) => {
-                return appInstance.agm;
-            });
-
-            if (instancesToTarget.length === 0) {
-                instancesToTarget = [await startAppAndWaitForIntentMethod(appTarget, intent)];
-            }
-        } else {
-            const methods = (window as WindowType).glue.interop.methods().filter((method) => {
-                return method.name === methodName;
-            });
-
-            instancesToTarget = methods[0]?.getServers();
-
-            if (!instancesToTarget || instancesToTarget.length === 0) {
-                const appTarget = ((window as WindowType).glue as Glue42Web.API).appManager.applications().find((application) => {
-                    return application.userProperties.intents?.some((appIntent: FDC3.Intent) => {
-                        return appIntent.name === intent;
-                    });
-                });
-
-                if (!appTarget) {
-                    throw new Error(FDC3.OpenError.AppNotFound);
-                }
-
-                instancesToTarget = [await startAppAndWaitForIntentMethod(appTarget, intent)];
-            }
-        }
-
-        invocationResult = (await (window as WindowType).glue.interop.invoke(methodName, context, instancesToTarget[0] || "best")).all_return_values;
-
-        if (invocationResult) {
-            return {
-                source: invocationResult[0].executed_by?.applicationName || "unknown",
-                version: "1.0.0",
-                data: invocationResult[0].returned
-            };
-        } else {
-            return {
-                source: "unknown",
-                version: "1.0.0"
-            };
-        }
-    };
-
-    const addIntentListener = (intent: string, handler: (context: FDC3.Context) => void): FDC3.Listener => {
-        let unsub: () => void;
-        let initialContext: FDC3.Context;
-
-        const methodName = `${GLUE42_CORE_FDC3_INTENTS_METHOD_PREFIX}${intent}`;
-
-        (window as WindowType).gluePromise
-            .then(() => {
-                return (window as WindowType).glue.windows.my().getContext();
-            })
-            .then((glueContext) => {
-                initialContext = glueContext?.intentContext;
-
-                return (window as WindowType).glue.interop.register(methodName, handler);
-            }).then(() => {
-                unsub = (): void => (window as WindowType).glue.interop.unregister(methodName);
-
-                if (initialContext) {
-                    handler(initialContext);
-                }
-            });
-
-        return {
-            unsubscribe: (): void => unsub()
-        };
-    };
-
-    return {
-        findIntent: async (...props): Promise<FDC3.AppIntent> => {
-            await (window as WindowType).gluePromise;
-            return findIntent(...props);
         },
-        findIntentsByContext: async (...props): Promise<FDC3.AppIntent[]> => {
-            await (window as WindowType).gluePromise;
-            return findIntentsByContext(...props);
-        },
-        raiseIntent: async (...props): Promise<FDC3.IntentResolution> => {
-            await (window as WindowType).gluePromise;
-            return raiseIntent(...props);
-        },
-        addIntentListener
-    };
-};
-
-const createGlue42EnterpriseDesktopAgent = (): Partial<FDC3.DesktopAgent> => {
-    const findIntent = async (intent: string, context?: FDC3.Context): Promise<FDC3.AppIntent> => {
-        const glueIntent = await ((window as WindowType).glue as Glue42.Glue).intents.find({ name: intent, contextType: context?.type });
-
-        if (!glueIntent) {
-            throw new Error(FDC3.ResolveError.NoAppsFound);
-        }
-
-        return convertGlue42IntentToFDC3AppIntent(glueIntent);
-    };
-
-
-    const findIntentsByContext = async (context: FDC3.Context): Promise<FDC3.AppIntent[]> => {
-        if (!context.type) {
-            throw new Error("Only filtering by context.type is supported.");
-        }
-        const glueIntents = await ((window as WindowType).glue as Glue42.Glue).intents.findByContext(context.type);
-
-        if (!glueIntents || glueIntents.length === 0) {
-            throw new Error(FDC3.ResolveError.NoAppsFound);
-        }
-
-        return glueIntents.map((gIntent) => convertGlue42IntentToFDC3AppIntent(gIntent));
-    };
-
-
-    const raiseIntent = async (intent: string, context: FDC3.Context, target?: string): Promise<FDC3.IntentResolution> => {
-        const glueIntentResult = await ((window as WindowType).glue as Glue42.Glue).intents.raise({ intent, context, target });
-
-        if (!glueIntentResult) {
-            throw new Error(`No intent resolution for ${intent}, context: ${JSON.stringify(context)}, target: ${target}`);
-        }
-
-        return {
-            source: glueIntentResult.applicationInstance,
-            version: "1.0.0"
-        };
-    };
-
-
-    const addIntentListener = (intent: string, handler: (context: FDC3.Context) => void): FDC3.Listener => {
-        let unsub: () => void;
-        let initialContext: FDC3.Context;
-
-        (window as WindowType).gluePromise
-            .then(() => {
-                return (window as WindowType).glue.windows.my().getContext();
-            })
-            .then((glueContext) => {
-                initialContext = glueContext?.intentContext;
-
-                // Fixed in @glue42/desktop@5.2.0.
-                unsub = ((window as WindowType).glue as Glue42.Glue).intents.addIntentListener(intent, handler as (context: object) => void) as unknown as () => {};
-
-                if (initialContext) {
-                    handler(initialContext);
-                }
-            });
-
-        return {
-            unsubscribe: (): void => unsub()
-        };
-    };
-
-    return {
         findIntent: async (...props): Promise<FDC3.AppIntent> => {
             await (window as WindowType).gluePromise;
             return findIntent(...props);
@@ -354,14 +150,12 @@ const createGlue42EnterpriseDesktopAgent = (): Partial<FDC3.DesktopAgent> => {
 };
 
 const createDesktopAgent = (): FDC3.DesktopAgent => {
-    const coreDesktopAgent = createCoreDesktopAgent();
-    const desktopAgent = isGlue42Core ? createGlue42CoreDesktopAgent() : createGlue42EnterpriseDesktopAgent();
-    const channelsAPI = createChannelsApi();
+    const intentsAgent = createIntentsAgent();
+    const channelsAgent = createChannelsAgent();
 
     return {
-        ...coreDesktopAgent,
-        ...desktopAgent,
-        ...channelsAPI
+        ...intentsAgent,
+        ...channelsAgent
     } as FDC3.DesktopAgent;
 };
 

--- a/packages/fdc3/src/channels/channels.ts
+++ b/packages/fdc3/src/channels/channels.ts
@@ -2,28 +2,7 @@ import { FDC3 } from "../../types";
 import { Glue42 } from "@glue42/desktop";
 import { SystemChannel, AppChannel } from "./channel";
 import { WindowType } from "../windowtype";
-import { getChannelsList, isGlue42Core, newSubscribe, isEmptyObject } from "../utils";
-
-const Listener = (actualUnsub:
-    (() => void)
-    | Promise<() => void>
-): FDC3.Listener => {
-    return {
-        unsubscribe(): void {
-            if (!actualUnsub) {
-                // tslint:disable-next-line:no-console
-                console.error("Could not unsubscribe!");
-                return;
-            }
-
-            if (typeof actualUnsub === "function") {
-                actualUnsub();
-            } else {
-                (actualUnsub as Promise<() => void>).then((unsubFunc: () => void) => unsubFunc());
-            }
-        }
-    };
-};
+import { getChannelsList, isGlue42Core, newSubscribe, isEmptyObject, Listener } from "../utils";
 
 interface PendingSubscription {
     contextType: string;
@@ -31,7 +10,7 @@ interface PendingSubscription {
     setActualUnsub: (actualUnsub: () => void) => void;
 }
 
-const createChannelsApi = (): FDC3.ChannelsAPI => {
+const createChannelsAgent = (): FDC3.ChannelsAPI => {
     let currentChannel: FDC3.Channel | null;
     let pendingSubscription: PendingSubscription | null;
 
@@ -198,7 +177,6 @@ const createChannelsApi = (): FDC3.ChannelsAPI => {
         await initDone;
 
         if (!currentChannel) {
-            // tslint:disable-next-line:no-console
             console.error("You must join a channel first.");
             return;
         }
@@ -216,7 +194,6 @@ const createChannelsApi = (): FDC3.ChannelsAPI => {
         const handler = arguments.length === 2 ? handlerInput : contextTypeInput;
 
         if (!currentChannel) {
-            // tslint:disable-next-line:no-console
             console.warn("You will start receiving broadcasts only after you join a channel !");
             const listener = createPendingListener(contextType, handler);
 
@@ -277,4 +254,4 @@ const createChannelsApi = (): FDC3.ChannelsAPI => {
     };
 };
 
-export default createChannelsApi;
+export default createChannelsAgent;

--- a/packages/fdc3/src/utils.ts
+++ b/packages/fdc3/src/utils.ts
@@ -1,3 +1,4 @@
+import { FDC3 } from "../types";
 import { Glue42 } from "@glue42/desktop";
 import { WindowType } from "./windowtype";
 
@@ -39,3 +40,23 @@ export const isEmptyObject = (obj: object): boolean => {
 };
 
 export const isGlue42Core = !navigator.userAgent.toLowerCase().includes(" electron/");
+
+export const Listener = (actualUnsub:
+    (() => void)
+    | Promise<() => void>
+): FDC3.Listener => {
+    return {
+        unsubscribe(): void {
+            if (!actualUnsub) {
+                console.error("Could not unsubscribe!");
+                return;
+            }
+
+            if (typeof actualUnsub === "function") {
+                actualUnsub();
+            } else {
+                (actualUnsub as Promise<() => void>).then((unsubFunc: () => void) => unsubFunc());
+            }
+        }
+    };
+};

--- a/packages/ng/package-lock.json
+++ b/packages/ng/package-lock.json
@@ -2523,9 +2523,9 @@
 			}
 		},
 		"@glue42/core": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/@glue42/core/-/core-5.1.2.tgz",
-			"integrity": "sha512-JfeP+O5ikhyg1/XGHApqf4DtA61nzH0EB3CNmuNYMmSvQ+KgR9QqBC9JMC+GM7NWecqboWHlQ+HmdZFAdpNXSw==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@glue42/core/-/core-5.2.3.tgz",
+			"integrity": "sha512-4ZstQ24zRWVYRoPBjiPTWVBWhR+u6hTVlzP88IC5o+k83syr6kNMFWpzsVNSwogj2LXA+wc99JOcSd35nEKEpw==",
 			"requires": {
 				"callback-registry": "^2.6.0",
 				"shortid": "^2.2.6",
@@ -2540,13 +2540,43 @@
 			}
 		},
 		"@glue42/desktop": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/@glue42/desktop/-/desktop-5.1.4.tgz",
-			"integrity": "sha512-b2iGe7lQ0SqoI2vd8cHEEEfP1eDRC/EiDVFsPdajApBOgJy1VKx4bYPGXRv7wFpNfmgtqLs4sDirUcqugqfERg==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@glue42/desktop/-/desktop-5.2.1.tgz",
+			"integrity": "sha512-aiD+BJBv9Ue1SqhkqkxNaC4WCQMaybYvizvOehmnWM7m71J967vG92xWxvHV/faiePffj6KvkT/nvm3OwBZSmA==",
 			"requires": {
-				"@glue42/core": "^5.0.7",
+				"@glue42/core": "^5.2.3",
+				"@glue42/workspaces-api": "^1.0.0",
 				"callback-registry": "^2.5.2",
 				"shortid": "2.2.8"
+			}
+		},
+		"@glue42/workspaces-api": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@glue42/workspaces-api/-/workspaces-api-1.0.4.tgz",
+			"integrity": "sha512-SqUEzHOJ/oKnDe2xtAIOzHi6nvSsgSCH7GHSQLk3DA0Nzom3vXs1leEZhlZyjfqG6zi4wmjsVTY2N1eP7OJiIA==",
+			"requires": {
+				"@glue42/core": "^5.2.3",
+				"callback-registry": "^2.5.2",
+				"decoder-validate": "0.0.1"
+			},
+			"dependencies": {
+				"@glue42/core": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@glue42/core/-/core-5.2.3.tgz",
+					"integrity": "sha512-4ZstQ24zRWVYRoPBjiPTWVBWhR+u6hTVlzP88IC5o+k83syr6kNMFWpzsVNSwogj2LXA+wc99JOcSd35nEKEpw==",
+					"requires": {
+						"callback-registry": "^2.6.0",
+						"shortid": "^2.2.6",
+						"ws": "7.1.2"
+					},
+					"dependencies": {
+						"callback-registry": {
+							"version": "2.6.0",
+							"resolved": "https://registry.npmjs.org/callback-registry/-/callback-registry-2.6.0.tgz",
+							"integrity": "sha512-whDyon3lSnlDAw4g+e0AAyNUtqqbPAyDj4h3Ofp4xbFib9aWCTgfChf6kVsXT/9FPWxDxFnXpPOgaR0V9ARxSw=="
+						}
+					}
+				}
 			}
 		},
 		"@istanbuljs/schema": {
@@ -3678,6 +3708,16 @@
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
 			"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
 			"dev": true
+		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
 		},
 		"blob": {
 			"version": "0.0.5",
@@ -5346,6 +5386,11 @@
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
 		},
+		"decoder-validate": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/decoder-validate/-/decoder-validate-0.0.1.tgz",
+			"integrity": "sha512-uwHIDbUJSSLGrLe0ZGNeF9b8YuDvRucBC7GE+a9Ot19Q2oQJkAxCDFS0zZUrTbFaRGhN/Yira2aftI10EPBxWQ=="
+		},
 		"decompress-response": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -6431,6 +6476,13 @@
 				"loader-utils": "^2.0.0",
 				"schema-utils": "^2.6.5"
 			}
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true,
+			"optional": true
 		},
 		"fileset": {
 			"version": "2.0.3",
@@ -9245,6 +9297,13 @@
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
+		},
+		"nan": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+			"dev": true,
+			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -14301,7 +14360,11 @@
 					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
 					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"bindings": "^1.5.0",
+						"nan": "^2.12.1"
+					}
 				},
 				"glob-parent": {
 					"version": "3.1.0",
@@ -14857,7 +14920,11 @@
 					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
 					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"bindings": "^1.5.0",
+						"nan": "^2.12.1"
+					}
 				},
 				"glob-parent": {
 					"version": "3.1.0",

--- a/packages/ng/package.json
+++ b/packages/ng/package.json
@@ -35,7 +35,7 @@
         "dist/"
     ],
     "dependencies": {
-        "@glue42/desktop": "^5.1.4",
+        "@glue42/desktop": "^5.2.1",
         "@glue42/web": "^1.4.4"
     },
     "devDependencies": {

--- a/packages/react-hooks/package-lock.json
+++ b/packages/react-hooks/package-lock.json
@@ -432,9 +432,9 @@
 			}
 		},
 		"@glue42/core": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/@glue42/core/-/core-5.1.2.tgz",
-			"integrity": "sha512-JfeP+O5ikhyg1/XGHApqf4DtA61nzH0EB3CNmuNYMmSvQ+KgR9QqBC9JMC+GM7NWecqboWHlQ+HmdZFAdpNXSw==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@glue42/core/-/core-5.2.3.tgz",
+			"integrity": "sha512-4ZstQ24zRWVYRoPBjiPTWVBWhR+u6hTVlzP88IC5o+k83syr6kNMFWpzsVNSwogj2LXA+wc99JOcSd35nEKEpw==",
 			"requires": {
 				"callback-registry": "^2.6.0",
 				"shortid": "^2.2.6",
@@ -449,13 +449,43 @@
 			}
 		},
 		"@glue42/desktop": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/@glue42/desktop/-/desktop-5.1.4.tgz",
-			"integrity": "sha512-b2iGe7lQ0SqoI2vd8cHEEEfP1eDRC/EiDVFsPdajApBOgJy1VKx4bYPGXRv7wFpNfmgtqLs4sDirUcqugqfERg==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@glue42/desktop/-/desktop-5.2.1.tgz",
+			"integrity": "sha512-aiD+BJBv9Ue1SqhkqkxNaC4WCQMaybYvizvOehmnWM7m71J967vG92xWxvHV/faiePffj6KvkT/nvm3OwBZSmA==",
 			"requires": {
-				"@glue42/core": "^5.0.7",
+				"@glue42/core": "^5.2.3",
+				"@glue42/workspaces-api": "^1.0.0",
 				"callback-registry": "^2.5.2",
 				"shortid": "2.2.8"
+			}
+		},
+		"@glue42/workspaces-api": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@glue42/workspaces-api/-/workspaces-api-1.0.4.tgz",
+			"integrity": "sha512-SqUEzHOJ/oKnDe2xtAIOzHi6nvSsgSCH7GHSQLk3DA0Nzom3vXs1leEZhlZyjfqG6zi4wmjsVTY2N1eP7OJiIA==",
+			"requires": {
+				"@glue42/core": "^5.2.3",
+				"callback-registry": "^2.5.2",
+				"decoder-validate": "0.0.1"
+			},
+			"dependencies": {
+				"@glue42/core": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@glue42/core/-/core-5.2.3.tgz",
+					"integrity": "sha512-4ZstQ24zRWVYRoPBjiPTWVBWhR+u6hTVlzP88IC5o+k83syr6kNMFWpzsVNSwogj2LXA+wc99JOcSd35nEKEpw==",
+					"requires": {
+						"callback-registry": "^2.6.0",
+						"shortid": "^2.2.6",
+						"ws": "7.1.2"
+					},
+					"dependencies": {
+						"callback-registry": {
+							"version": "2.6.0",
+							"resolved": "https://registry.npmjs.org/callback-registry/-/callback-registry-2.6.0.tgz",
+							"integrity": "sha512-whDyon3lSnlDAw4g+e0AAyNUtqqbPAyDj4h3Ofp4xbFib9aWCTgfChf6kVsXT/9FPWxDxFnXpPOgaR0V9ARxSw=="
+						}
+					}
+				}
 			}
 		},
 		"@istanbuljs/load-nyc-config": {
@@ -1808,6 +1838,11 @@
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
+		},
+		"decoder-validate": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/decoder-validate/-/decoder-validate-0.0.1.tgz",
+			"integrity": "sha512-uwHIDbUJSSLGrLe0ZGNeF9b8YuDvRucBC7GE+a9Ot19Q2oQJkAxCDFS0zZUrTbFaRGhN/Yira2aftI10EPBxWQ=="
 		},
 		"deep-is": {
 			"version": "0.1.3",

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -72,7 +72,7 @@
         "typescript": "^3.8.3"
     },
     "dependencies": {
-        "@glue42/desktop": "^5.1.4",
+        "@glue42/desktop": "^5.2.1",
         "@glue42/web": "^1.4.4",
         "prop-types": "^15.7.2"
     }

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -238,31 +238,32 @@
 			}
 		},
 		"@glue42/core": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@glue42/core/-/core-5.0.7.tgz",
-			"integrity": "sha512-fNc9ozX7HAx8+/pYeT7coXzXXc32LeNHR0DmwL6MEsCwAt42crhbvb2yOZI8OT+TVQtQ81KIJ5PcEGvDNxYxtA==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@glue42/core/-/core-5.2.3.tgz",
+			"integrity": "sha512-4ZstQ24zRWVYRoPBjiPTWVBWhR+u6hTVlzP88IC5o+k83syr6kNMFWpzsVNSwogj2LXA+wc99JOcSd35nEKEpw==",
 			"dev": true,
 			"requires": {
-				"callback-registry": "^2.5.2",
-				"shortid": "2.2.6",
+				"callback-registry": "^2.6.0",
+				"shortid": "^2.2.6",
 				"ws": "7.1.2"
 			},
 			"dependencies": {
-				"shortid": {
-					"version": "2.2.6",
-					"resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.6.tgz",
-					"integrity": "sha1-OrvvxsUQdM8sHx5y9iFqG0WHbXI=",
+				"callback-registry": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/callback-registry/-/callback-registry-2.6.0.tgz",
+					"integrity": "sha512-whDyon3lSnlDAw4g+e0AAyNUtqqbPAyDj4h3Ofp4xbFib9aWCTgfChf6kVsXT/9FPWxDxFnXpPOgaR0V9ARxSw==",
 					"dev": true
 				}
 			}
 		},
 		"@glue42/desktop": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/@glue42/desktop/-/desktop-5.1.4.tgz",
-			"integrity": "sha512-b2iGe7lQ0SqoI2vd8cHEEEfP1eDRC/EiDVFsPdajApBOgJy1VKx4bYPGXRv7wFpNfmgtqLs4sDirUcqugqfERg==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@glue42/desktop/-/desktop-5.2.1.tgz",
+			"integrity": "sha512-aiD+BJBv9Ue1SqhkqkxNaC4WCQMaybYvizvOehmnWM7m71J967vG92xWxvHV/faiePffj6KvkT/nvm3OwBZSmA==",
 			"dev": true,
 			"requires": {
-				"@glue42/core": "^5.0.7",
+				"@glue42/core": "^5.2.3",
+				"@glue42/workspaces-api": "^1.0.0",
 				"callback-registry": "^2.5.2",
 				"shortid": "2.2.8"
 			},
@@ -273,6 +274,17 @@
 					"integrity": "sha1-AzsRfWoul1gE9vCWnb59PQs1UTE=",
 					"dev": true
 				}
+			}
+		},
+		"@glue42/workspaces-api": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@glue42/workspaces-api/-/workspaces-api-1.0.4.tgz",
+			"integrity": "sha512-SqUEzHOJ/oKnDe2xtAIOzHi6nvSsgSCH7GHSQLk3DA0Nzom3vXs1leEZhlZyjfqG6zi4wmjsVTY2N1eP7OJiIA==",
+			"dev": true,
+			"requires": {
+				"@glue42/core": "^5.2.3",
+				"callback-registry": "^2.5.2",
+				"decoder-validate": "0.0.1"
 			}
 		},
 		"@glue42/ws-gateway": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -40,7 +40,7 @@
         "shortid": "^2.2.15"
     },
     "devDependencies": {
-        "@glue42/desktop": "^5.1.4",
+        "@glue42/desktop": "^5.2.1",
         "@glue42/ws-gateway": "^3.0.8-beta.1",
         "@rollup/plugin-commonjs": "^13.0.0",
         "@rollup/plugin-json": "^4.1.0",

--- a/packages/web/src/intents/main.ts
+++ b/packages/web/src/intents/main.ts
@@ -1,0 +1,253 @@
+import { Glue42Web } from "../../web";
+import { AppDefinition } from "./types";
+import { UnsubscribeFunction } from "callback-registry";
+import { glue42CoreIntentFilterDecoder, glue42CoreIntentDefinitionDecoder, glue42CoreIntentRequestDecoder } from "../shared/decoders/intents";
+
+const GLUE42_FDC3_INTENTS_METHOD_PREFIX = "Tick42.FDC3.Intents.";
+
+export class Intents implements Glue42Web.Intents.API {
+    constructor(private interop: Glue42Web.Interop.API, private windows: Glue42Web.Windows.API, private appManager: Glue42Web.AppManager.API) {
+    }
+
+    public async find(intentFilter?: string | Glue42Web.Intents.IntentFilter): Promise<Glue42Web.Intents.Intent[]> {
+        glue42CoreIntentFilterDecoder.runWithException(intentFilter);
+
+        let intents = await this.all();
+        if (typeof intentFilter === "undefined") {
+            return intents;
+        }
+
+        if (typeof intentFilter === "string") {
+            return intents.filter((intent) => intent.name === intentFilter);
+        }
+
+        if (intentFilter.contextType) {
+            const ctToLower = intentFilter.contextType.toLowerCase();
+            intents = intents.filter((intent) => intent.handlers.some((handler) => handler.contextTypes?.some((ct) => ct.toLowerCase() === ctToLower)));
+        }
+
+        if (intentFilter.name) {
+            intents = intents.filter((intent) => intent.name === intentFilter.name);
+        }
+
+        return intents;
+    }
+
+    public async raise(intent: string | Glue42Web.Intents.IntentRequest): Promise<Glue42Web.Intents.IntentResult> {
+        glue42CoreIntentRequestDecoder.runWithException(intent);
+
+        if (typeof intent === "string") {
+            intent = {
+                intent
+            };
+        }
+
+        const intentName = intent.intent;
+        const intentDef = await this.get(intentName);
+
+        if (typeof intentDef === "undefined") {
+            throw new Error(`Intent ${intentName} not found.`);
+        }
+
+        const isDynamicIntent = !intentDef.handlers.some((intentDefHandler) => intentDefHandler.type === "app");
+
+        // Default to "reuse" in the case of a dynamic intent and to "startNew" if target isn't provided.
+        const target = intent.target || (isDynamicIntent ? "reuse" : "startNew");
+        // The handler that will execute the intent.
+        let handler: Glue42Web.Intents.IntentHandler;
+        const anAppHandler = intentDef.handlers.find((intentHandler) => intentHandler.type === "app");
+        if (target === "startNew") {
+            handler = anAppHandler;
+        } else if (target === "reuse") {
+            const anInstanceHandler = intentDef.handlers.find((intentHandler) => intentHandler.type === "instance");
+            handler = anInstanceHandler || anAppHandler;
+        } else if (target.instance) {
+            handler = intentDef.handlers.find((intentHandler) => intentHandler.type === "instance" && intentHandler.instanceId === target.instance);
+        } else if (target.app) {
+            handler = intentDef.handlers.find((intentHandler) => intentHandler.type === "app" && intentHandler.applicationName === target.app);
+        } else {
+            throw new Error(`Invalid intent target: ${JSON.stringify(target)}`);
+        }
+
+        if (!handler) {
+            throw new Error(`Can not raise intent for request ${JSON.stringify(intent)} - can not find intent handler.`);
+        }
+
+        let instanceId = handler.instanceId;
+        if (handler.type === "app") {
+            instanceId = await this.startApp(handler.applicationName, intent.options);
+        }
+
+        const result: Partial<Glue42Web.Intents.IntentResult> = await this.raiseIntentToInstance(instanceId, intentName, intent.context);
+        result.request = intent;
+        result.handler = handler;
+
+        return result as Glue42Web.Intents.IntentResult;
+    }
+
+    public async all(): Promise<Glue42Web.Intents.Intent[]> {
+        // Gathers all intents from:
+        // 1. Application definitions
+        // 2. Running instances (application can register dynamic intents by calling `addIntentListener()` that aren't predefined inside of their application definitions)
+        // It also populates intent handlers (actual entities that can handle the intent).
+        const apps: AppDefinition[] = this.appManager.applications().map((app: Glue42Web.AppManager.Application) => {
+            return {
+                name: app.name,
+                title: app.title,
+                intents: app.userProperties.intents
+            };
+        });
+        const intents: { [key: string]: Glue42Web.Intents.Intent } = {};
+        const appsWithIntents = apps.filter((app) => app.intents && app.intents.length > 0);
+        //  Gather app handlers from application definitions.
+        for (const app of appsWithIntents) {
+            for (const intentDef of app.intents) {
+                let intent = intents[intentDef.name];
+                if (!intent) {
+                    intent = {
+                        name: intentDef.name,
+                        handlers: [],
+                    };
+                    intents[intentDef.name] = intent;
+                }
+
+                const handler: Glue42Web.Intents.IntentHandler = {
+                    applicationName: app.name,
+                    displayName: intentDef.displayName,
+                    contextTypes: intentDef.contexts,
+                    type: "app"
+                };
+
+                intent.handlers.push(handler);
+            }
+        }
+
+        // Discover all running instances that provide intents, and add them to the corresponding intent.
+        for (const server of this.interop.servers()) {
+            await Promise.all(server.getMethods()
+                .filter((method) => method.name.startsWith(GLUE42_FDC3_INTENTS_METHOD_PREFIX))
+                .map(async (method) => {
+                    const intentName = method.name.replace(GLUE42_FDC3_INTENTS_METHOD_PREFIX, "");
+                    let intent = intents[intentName];
+                    if (!intent) {
+                        intent = {
+                            name: intentName,
+                            handlers: [],
+                        };
+                        intents[intentName] = intent;
+                    }
+
+                    let info: { contextTypes?: string[], displayName?: string };
+                    if (method.description) {
+                        try {
+                            info = JSON.parse(method.description);
+                        } catch { /* DO NOTHING */ }
+                    }
+
+                    const app = appsWithIntents.find((appWithIntents) => appWithIntents.name === server.application);
+                    // app can be undefined in the case of a dynamic intent.
+                    const appIntent = app?.intents.find((appDefIntent) => appDefIntent.name === intentName);
+
+                    const window = this.windows.findById(server.windowId);
+                    const title = await window?.getTitle();
+                    const handler: Glue42Web.Intents.IntentHandler = {
+                        instanceId: server.instance,
+                        applicationName: server.application,
+                        displayName: info?.displayName || appIntent?.displayName,
+                        contextTypes: info?.contextTypes || appIntent?.contexts,
+                        instanceTitle: title,
+                        type: "instance"
+                    };
+                    intent.handlers.push(handler);
+                }));
+        }
+
+        return Object.values(intents);
+    }
+
+    public addIntentListener(intent: string | { intent: string, contextTypes?: string[], displayName?: string }, handler: (context: Glue42Web.Intents.IntentContext) => any): { unsubscribe: UnsubscribeFunction } {
+        glue42CoreIntentDefinitionDecoder.runWithException(intent);
+        if (typeof handler !== "function") {
+            throw new Error("Please provide the handler as a function!");
+        }
+
+        // `addIntentListener()` is sync.
+        // tslint:disable-next-line:no-console
+        const result: { unsubscribe: () => void } = { unsubscribe: () => console.log("Could not unsubscribe!") };
+        const intentName = typeof intent === "string" ? intent : intent.intent;
+        const methodName = `${GLUE42_FDC3_INTENTS_METHOD_PREFIX}${intentName}`;
+        const methodDescription = typeof intent === "string" ? undefined : JSON.stringify(intent);
+
+        this.interop.register({ name: methodName, description: methodDescription }, (args: Glue42Web.Intents.IntentContext) => {
+            return handler(args);
+        }).then(() => {
+            result.unsubscribe = () => {
+                this.interop.unregister(methodName);
+            };
+        });
+
+        return result;
+    }
+
+    private async get(intent: string): Promise<Glue42Web.Intents.Intent> {
+        return (await this.all()).find((registeredIntent) => registeredIntent.name === intent);
+    }
+
+    private async startApp(application: string, options?: Glue42Web.AppManager.ApplicationStartOptions) {
+        const instance = await this.appManager.application(application).start({}, options);
+
+        return instance.id;
+    }
+
+    private async raiseIntentToInstance(instanceId: string, intent: string, context?: Glue42Web.Intents.IntentContext): Promise<{ result: any }> {
+        const methodName = `${GLUE42_FDC3_INTENTS_METHOD_PREFIX}${intent}`;
+        let interopServer = this.interop.servers().find((server) => server.instance === instanceId);
+        if (!interopServer) {
+            // Wait 30 sec for the server to appear.
+            await (new Promise((resolve, reject) => {
+                let timeoutId: any;
+
+                const unsub = this.interop.serverAdded((server) => {
+                    if (server.instance === instanceId) {
+                        interopServer = server;
+                        resolve();
+                        clearTimeout(timeoutId);
+                        unsub();
+                    }
+                });
+
+                timeoutId = setTimeout(() => {
+                    unsub();
+                    reject(new Error(`Can not find interop server for instance ${instanceId}`));
+                }, 30 * 1000);
+            }));
+        }
+
+        const method = interopServer.getMethods().find((registeredMethod) => registeredMethod.name === methodName);
+        if (!method) {
+            // Wait 10 sec for the method to appear.
+            await (new Promise((resolve, reject) => {
+                let timeoutId: any;
+
+                const unsub = this.interop.methodAdded((addedMethod) => {
+                    if (addedMethod.name === methodName) {
+                        resolve();
+                        clearTimeout(timeoutId);
+                        unsub();
+                    }
+                });
+
+                timeoutId = setTimeout(() => {
+                    unsub();
+                    reject(new Error(`Can not find interop method ${methodName} for instance ${instanceId}`));
+                }, 10 * 1000);
+            }));
+        }
+
+        const result = await this.interop.invoke(methodName, context, { instance: instanceId });
+
+        return {
+            result: result.returned
+        };
+    }
+}

--- a/packages/web/src/intents/types.ts
+++ b/packages/web/src/intents/types.ts
@@ -1,0 +1,11 @@
+export interface IntentInfo {
+    name: string;
+    displayName?: string;
+    contexts: string[];
+}
+
+export interface AppDefinition {
+    name: string;
+    title: string;
+    intents: IntentInfo[];
+}

--- a/packages/web/src/shared/decoders/app-manager.ts
+++ b/packages/web/src/shared/decoders/app-manager.ts
@@ -20,7 +20,7 @@ const fdc3IntentDecoder: Decoder<Intent> = object({
 });
 
 const glue42CoreCreateOptionsDecoder: Decoder<Glue42Web.Windows.CreateOptions> = object({
-    url: nonEmptyStringDecoder,
+    url: optional(nonEmptyStringDecoder),
     top: optional(number()),
     left: optional(number()),
     width: optional(number()),

--- a/packages/web/src/shared/decoders/intents.ts
+++ b/packages/web/src/shared/decoders/intents.ts
@@ -1,0 +1,59 @@
+import { Decoder, object, optional, array, string, number, anyJson, constant, oneOf } from "decoder-validate";
+import { Glue42Web } from "../../../web";
+
+const nonEmptyStringDecoder: Decoder<string> = string().where((s) => s.length > 0, "Expected a non-empty string");
+
+const glue42CoreCreateOptionsDecoder: Decoder<Glue42Web.AppManager.ApplicationStartOptions> = object({
+    url: optional(nonEmptyStringDecoder),
+    top: optional(number()),
+    left: optional(number()),
+    width: optional(number()),
+    height: optional(number()),
+    context: optional(anyJson()),
+    relativeTo: optional(nonEmptyStringDecoder),
+    relativeDirection: optional(oneOf<"top" | "left" | "right" | "bottom">(
+        constant("top"),
+        constant("left"),
+        constant("right"),
+        constant("bottom")
+    ))
+});
+
+const glue42CoreIntentContextDecoder: Decoder<Glue42Web.Intents.IntentContext> = object({
+    type: optional(nonEmptyStringDecoder),
+    data: optional(object())
+});
+
+export const glue42CoreIntentFilterDecoder: Decoder<string | Glue42Web.Intents.IntentFilter> = oneOf<string | Glue42Web.Intents.IntentFilter>(
+    object({
+        name: optional(string()),
+        contextType: optional(string())
+    }),
+    nonEmptyStringDecoder
+);
+
+export const glue42CoreIntentDefinitionDecoder: Decoder<string | { intent: string, contextTypes?: string[], displayName?: string }> = oneOf<string | { intent: string, contextTypes?: string[], displayName?: string }>(
+    object({
+        intent: nonEmptyStringDecoder,
+        contextTypes: optional(array(string())),
+        displayName: optional(string())
+    }),
+    nonEmptyStringDecoder
+);
+
+export const glue42CoreIntentRequestDecoder: Decoder<string | Glue42Web.Intents.IntentRequest> = oneOf<string | Glue42Web.Intents.IntentRequest>(
+    object({
+        intent: nonEmptyStringDecoder,
+        target: optional(oneOf<"startNew" | "reuse" | { app?: string; instance?: string }>(
+            constant("startNew"),
+            constant("reuse"),
+            object({
+                app: optional(string()),
+                instance: optional(string())
+            })
+        )),
+        context: optional(glue42CoreIntentContextDecoder),
+        options: optional(glue42CoreCreateOptionsDecoder)
+    }),
+    nonEmptyStringDecoder
+);

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -1,6 +1,5 @@
 
 import { Glue42 } from "@glue42/desktop";
-import { Glue42Web } from "../web";
 
 /** Optional context passed to new windows */
 export interface StartingContext {
@@ -9,12 +8,8 @@ export interface StartingContext {
     parent: string; // id of the parent window
 }
 
-interface Glue42Config extends Glue42.Config {
-    libraries?: Array<(glue: Glue42Web.API, config?: Glue42Web.Config) => Promise<void>>;
-}
-
 /** Extra objects available in the global window object when your app is running in Glue42 Enterprise  */
 export interface Glue42DesktopWindowContext {
     glue42gd: Glue42.GDObject;
-    Glue: (config?: Glue42Config) => Promise<Glue42.Glue>;
+    Glue: (config?: Glue42.Config) => Promise<Glue42.Glue>;
 }

--- a/packages/web/web.d.ts
+++ b/packages/web/web.d.ts
@@ -126,7 +126,7 @@ export namespace Glue42Web {
         /**
          * A list of glue libraries which will be initiated internally and provide access to specific functionalities
          */
-        libraries?: Array<(glue: Glue42Web.API, config?: Glue42Web.Config) => Promise<void>>;
+        libraries?: Array<(glue: Glue42Web.API, config?: Glue42Web.Config | Glue42.Config) => Promise<void>>;
     }
 
     /**
@@ -141,6 +141,7 @@ export namespace Glue42Web {
         notifications: Glue42Web.Notifications.API;
         channels: Glue42Web.Channels.API;
         appManager: Glue42Web.AppManager.API;
+        intents: Glue42Web.Intents.API;
         workspaces?: Glue42Workspaces.API;
     }
 
@@ -373,7 +374,7 @@ export namespace Glue42Web {
          * @docmenuorder 11
          *
          */
-        export type LayoutType = "Global" | "Workspace" | "Activity";
+        export type LayoutType = "Global" | "Activity" | "ApplicationDefault" | "Swimlane" | "Workspace";
 
         /**
          * Controls the import behavior. If `replace` (default), all existing layouts will be removed.
@@ -843,6 +844,176 @@ export namespace Glue42Web {
              * @returns Promise that resolves when the instance has been stopped.
             */
             stop(): Promise<void>;
+        }
+    }
+
+    /**
+     * @docmenuorder 9
+     * @ignore
+     */
+    namespace Intents {
+        export interface API {
+            /**
+             * Raises an intent, optionally passing context to the intent handlers, and optionally targeting specific intent handlers.
+             * If no handlers are matching the targeting conditions the promise will be rejected.
+             * @param request can be the intent's name or an {@link IntentRequest} object carrying the intent, and its optional target, context and start options (see "startNew").
+             * @returns Promise that resolves with {@link IntentResult}.
+             */
+            raise(request: string | IntentRequest): Promise<IntentResult>;
+
+            /**
+             * Returns all registered {@link Intent}.
+             * @returns Promise that resolves with all registered intents.
+             */
+            all(): Promise<Intent[]>;
+
+            /**
+             * If your application is an intent handler use this method to handle incoming intent requests.
+             * Please note that when a new instance of your application is started as a result of a raised intent with e.g. `startNew` your application needs to call `addIntentListener()` on startup so that the intent can be resolved.
+             * The handler callback will be invoked whenever an intent is raised and your app was selected as an IntentTarget.
+             * You can also use this method to register new dynamic intents, that will have the the same lifespan as your application instance.
+             * @param intent The intent to be handled. The intent name of an object containing the intent, contextTypes that the intent can handle and a display name.
+             * @param handler The callback that will handle a raised intent. Will be called with an {@link IntentContext} if it is provided by the raising application.
+             * @returns An object with an unsubscribe function under the unsubscribe property.
+             */
+            addIntentListener(intent: string | { intent: string, contextTypes?: string[], displayName?: string }, handler: (context: IntentContext) => any): { unsubscribe: UnsubscribeFunction };
+
+            /**
+             * Searches for registered intents.
+             * @param intentFilter can be the intent name or a {@link IntentFilter} filtering criteria.
+             * @returns Promise that resolves with the found intents that match the provided filtering criteria.
+             */
+            find(intentFilter?: string | IntentFilter): Promise<Intent[]>;
+        }
+
+        /**
+         * Specifies the search criteria for the Intent API's `find()` method.
+         */
+        export interface IntentFilter {
+            /**
+             * The name of the intent to be used in the lookup.
+             */
+            name?: string;
+            /**
+             * The name of the context type to be used in the lookup.
+             */
+            contextType?: string;
+        }
+
+        /**
+         * Represents an intent.
+         */
+        export interface Intent {
+            /**
+             * The name of the intent, such as `"CreateCall"`.
+             */
+            readonly name: string;
+            /**
+             * The set of {@link IntentHandler} that provide an implementation for the intent and can be used to handle an intent request.
+             */
+            handlers: IntentHandler[];
+        }
+
+        /**
+         * Represents an implementation of an intent.
+         * Each intent handler can offer its own display name - this allows context menus
+         * built on the fly to display more user friendly options. For example, if there is
+         * an intent with a name "ShowNews", there could be a handler with display name
+         * "Show Bloomberg News" and another with display name "Show Reuters News".
+         * Handlers can optionally specify the context type they support, where the
+         * context type is the name of a typed, documented data structure such as
+         * "Person", "Team", "Instrument", "Order", etc. In the example above,
+         * both the Bloomberg and Reuters handlers would specify a context type "Instrument" and
+         * would expect to be raised with an instrument object conforming to an expected
+         * structure from both handlers.
+         * An intent handler must not necessarily specify a context type.
+         */
+        export interface IntentHandler {
+            /**
+             * The name of the application which registered this intent implementation.
+             */
+            readonly applicationName: string;
+            /**
+             * The type of the handler.
+             * "app" - An application that has declared itself as an implementor of the intent inside of its application definition.
+             * "instance" - A running instance of an application that can handle the intent. Also includes dynamically added intents using `addIntentListener()`.
+             */
+            readonly type: "app" | "instance";
+            /**
+             * The human-readable name of the intent handler.
+             */
+            readonly displayName?: string;
+            /**
+             * The context types this handler supports.
+             */
+            readonly contextTypes?: string[];
+            /**
+             * The id of the running application instance.
+             */
+            readonly instanceId?: string;
+            /**
+             * The window's title of the running application instance.
+             */
+            readonly instanceTitle?: string;
+        }
+
+        /**
+         * Represents a request to raise an intent.
+         */
+        export interface IntentRequest {
+            /**
+             * The name of the intent to be raised.
+             */
+            readonly intent: string;
+            /**
+             * Тhe target of the raised intent. Valid values are:
+             * `startNew` - will start a new instance of an application that can handle the intent.
+             * `reuse` - a running instance of an application will handle the intent.
+             * { app: "AppName" } - will start a new instance of the "AppName" application (iff it can handle it) that will handle the intent.
+             * { instance: "i-123-1" } - the running application instance with instanceId "i-123-1" will handle the intent (iff it can handle it).
+             */
+            readonly target?: "startNew" | "reuse" | { app?: string; instance?: string };
+            /**
+             * The context type and data that will be provided to the intent implementation's handler.
+             */
+            readonly context?: IntentContext;
+            /**
+             * Start up options that will be used when a new instance of an application needs to be started to handle the intent request.
+             */
+            readonly options?: AppManager.ApplicationStartOptions;
+        }
+
+        /**
+         * A structure that describes a typed context to be used to raise intents with.
+         */
+        export interface IntentContext {
+            /**
+             * The name of a typed, documented data structure such as "Person", "Team", "Instrument", "Order", etc.
+             * It is the application developers' job to agree on a protocol to follow.
+             */
+            readonly type?: string;
+            /**
+             * The context data used as an argument by the intent implementation.
+             */
+            readonly data?: { [key: string]: any };
+        }
+
+        /**
+         * The result of a raised intent.
+         */
+        export interface IntentResult {
+            /**
+             * The arguments that were used to raise the intent with.
+             */
+            request: IntentRequest;
+            /**
+             * The intent implementation that handled the intent.
+             */
+            handler: IntentHandler;
+            /**
+             * The data returned by the intent implementation when handling the intent.
+             */
+            result?: any;
         }
     }
 }


### PR DESCRIPTION
Instantiate AppManager always as Intents depends on it, but only attach it to the glue object when the user passes appManager: true
Use the @glue42/web Intents API for the @glue42/fdc3 Glue42Core implementation
Bump to @glue42/desktop@5.2.1
Add decoder validation for the Intents API
Change `raise()` to default to "reuse" in the case of a dynamic intent