### PR TITLE
Add an optional requestTimeout property to the RemoteSource interface

### DIFF
--- a/docs/core/03_capabilities/02_application-management/application-management.md
+++ b/docs/core/03_capabilities/02_application-management/application-management.md
@@ -12,7 +12,7 @@ To enable the Application Management API in your applications, you need to provi
 
 ### Application Definitions
 
-To define application configurations you have to use the `appManager` top-level key of the `glue.config.json` file of your project. You can provide application definitions directly in the `glue.config.json` file and/or from a remote application configuration store. 
+To define application configurations you have to use the `appManager` top-level key of the `glue.config.json` file of your project. You can provide application definitions directly in the `glue.config.json` file and/or from a remote application configuration store.
 
 *For more detailed explanations on the available properties for configuring applications, see the [Glue42 Environment: Configuration File](../../core-concepts/environment/overview/index.html#configuration_file) section.*
 
@@ -20,7 +20,7 @@ To define application configurations you have to use the `appManager` top-level 
 
 - #### Local Application Definitions
 
-Use the `localApplications` property of the `appManager` top-level key to define applications directly inside the `glue.config.json` file. Below is an example configuration for two applications: 
+Use the `localApplications` property of the `appManager` top-level key to define applications directly inside the `glue.config.json` file. Below is an example configuration for two applications:
 
 ```json
 {
@@ -92,7 +92,8 @@ Below is an example configuration for a remote application definition store that
         "remoteSources": [
             {
                 "url": "http://localhost:3001/v1/apps/search",
-                "pollingInterval": 5000
+                "pollingInterval": 5000,
+                "requestTimeout": 10000
             }
         ]
     }

--- a/docs/core/03_capabilities/99_fdc3-compliance/fdc3-compliance.md
+++ b/docs/core/03_capabilities/99_fdc3-compliance/fdc3-compliance.md
@@ -119,7 +119,8 @@ To configure **Glue42 Core** to retrieve application definitions from remote app
         "remoteSources": [
             {
                 "url": "http://localhost:3001/v1/apps/search",
-                "pollingInterval": 5000
+                "pollingInterval": 5000,
+                "requestTimeout": 10000
             }
         ]
     }

--- a/docs/core/04_core-concepts/02_environment/01_overview/overview.md
+++ b/docs/core/04_core-concepts/02_environment/01_overview/overview.md
@@ -107,7 +107,8 @@ A `RemoteSource` has the following properties:
 | Property | Type | Description | Required | Default |
 |----------|------|-------------|----------|---------|
 | `url` | `string` | The URL of the remote source of application definitions. The provided application definitions need to be of type `Glue42CoreApplicationConfig`. | Yes | `-` |
-| `pollingInterval` | `number` | The polling interval for fetching application definitions from the remote source. | No | `3000` |
+| `pollingInterval` | `number` | The polling interval for fetching application definitions from the remote source in milliseconds. | No | `3000` |
+| `requestTimeout` | `number` | The request timeout for fetching application definitions from the remote source in milliseconds. | No | `3000` |
 
 The expected response from the remote application store is in JSON format and with the following shape:
 
@@ -166,7 +167,8 @@ Below is an example configuration for defining local and remote application defi
         "remoteSources": [
             {
                 "url": "http://localhost:3001/v1/apps/search",
-                "pollingInterval": 5000
+                "pollingInterval": 5000,
+                "requestTimeout": 10000
             }
         ]
     }

--- a/packages/web/src/app-manager/main.ts
+++ b/packages/web/src/app-manager/main.ts
@@ -23,6 +23,7 @@ export class AppManager implements Glue42Web.AppManager.API {
     private registry: CallbackRegistry = CallbackRegistryFactory();
 
     private DEFAULT_POLLING_INTERVAL = 3000;
+    private DEFAULT_REQUEST_TIMEOUT = 3000;
     private OKAY_MESSAGE = "OK";
     private LOCAL_SOURCE = "LOCAL_SOURCE";
     private readyPromise: Promise<void>;
@@ -163,7 +164,7 @@ export class AppManager implements Glue42Web.AppManager.API {
             const url = remoteSource.url;
 
             const appsFetch = async () => {
-                const response = await fetchTimeout(url, 1000);
+                const response = await fetchTimeout(url, remoteSource.requestTimeout || this.DEFAULT_REQUEST_TIMEOUT);
                 const json = (await response.json()) as { message: string; applications: Array<Glue42CoreApplicationConfig | FDC3ApplicationConfig> };
 
                 if (json.message === this.OKAY_MESSAGE) {

--- a/packages/web/src/glue.config.d.ts
+++ b/packages/web/src/glue.config.d.ts
@@ -181,7 +181,14 @@ export interface RemoteSource {
     url: string;
 
     /**
-     * The polling interval for fetching from the remote source.
+     * The polling interval for fetching application definitions from the remote source in milliseconds.
+     * @default 3000
      */
     pollingInterval?: number;
+
+    /**
+     * The request timeout for fetching application definitions from the remote source in milliseconds.
+     * @default 3000
+     */
+    requestTimeout?: number;
 }

--- a/packages/web/src/layouts/stores/json.ts
+++ b/packages/web/src/layouts/stores/json.ts
@@ -2,6 +2,7 @@ import { RemoteStore } from "../types";
 import { Glue42Web } from "../../../web";
 import { layoutTypeDecoder, layoutDecoder } from "../validation/";
 import { defaultLayoutsName } from "../../config/defaults";
+import { fetchTimeout } from "../../utils";
 
 export class JSONStore implements RemoteStore {
 
@@ -13,7 +14,7 @@ export class JSONStore implements RemoteStore {
 
         const fetchUrl = `${this.storeBaseUrl}/${defaultLayoutsName}`;
 
-        const response = await this.fetchTimeout(fetchUrl);
+        const response = await fetchTimeout(fetchUrl);
 
         if (!response.ok) {
             return [];
@@ -51,29 +52,5 @@ export class JSONStore implements RemoteStore {
         const allLayouts = await this.getAll(layoutType);
 
         return allLayouts.find((layout) => layout.name === name);
-    }
-
-    private fetchTimeout(url: string, timeoutMilliseconds = 1000): Promise<Response> {
-        return new Promise((resolve, reject) => {
-            let timeoutHit = false;
-            const timeout = setTimeout(() => {
-                timeoutHit = true;
-                reject(new Error(`Fetch request for: ${url} timed out at: ${timeoutMilliseconds} milliseconds`));
-            }, timeoutMilliseconds);
-
-            fetch(url)
-                .then((response) => {
-                    if (!timeoutHit) {
-                        clearTimeout(timeout);
-                        resolve(response);
-                    }
-                })
-                .catch((err) => {
-                    if (!timeoutHit) {
-                        clearTimeout(timeout);
-                        reject(err);
-                    }
-                });
-        });
     }
 }

--- a/packages/web/src/utils/index.ts
+++ b/packages/web/src/utils/index.ts
@@ -1,4 +1,4 @@
-export const fetchTimeout = (url: string, timeoutMilliseconds = 1000): Promise<Response> => {
+export const fetchTimeout = (url: string, timeoutMilliseconds = 3000): Promise<Response> => {
     return new Promise((resolve, reject) => {
         let timeoutHit = false;
         const timeout = setTimeout(() => {


### PR DESCRIPTION
Change the `fetchTimeout()`'s default timeoutMilliseconds from 1000 to 3000