### PR TITLE
Replace a static API InstanceWrapper property with an injected API

### DIFF
--- a/packages/core/src/interop/client/client.ts
+++ b/packages/core/src/interop/client/client.ts
@@ -534,46 +534,23 @@ export default class Client {
                     && prop[0] !== "_";
             });
 
-        return filterProps.reduce<boolean>((isMatch, prop) => {
+        return filterProps.every((prop) => {
+            let isMatch;
+
             const filterValue = filter[prop];
             const repoMethodValue = repoMethod[prop];
 
             if (prop === "objectTypes") {
-                const containsAllFromFilter = (filterObjTypes: string[], repoObjectTypes: string[]) => {
-                    const objTypeToContains = filterObjTypes.reduce<{ [objType: string]: boolean }>(
-                        (object, objType: string) => {
-                            object[objType] = false;
-                            return object;
-                        }, {}
-                    );
-
-                    repoObjectTypes.forEach((repoObjType: string) => {
-                        if (objTypeToContains[repoObjType] !== undefined) {
-                            objTypeToContains[repoObjType] = true;
-                        }
-                    });
-
-                    const filterIsFullfilled = () => Object.keys(objTypeToContains).reduce<boolean>((isFullfiled, objType: string) => {
-                        if (!objTypeToContains[objType]) {
-                            isFullfiled = false;
-                        }
-                        return isFullfiled;
-                    }, true);
-
-                    return filterIsFullfilled();
-                };
-
-                if (filterValue.length > repoMethodValue.length
-                    || containsAllFromFilter(filterValue, repoMethodValue) === false) {
-                    isMatch = false;
-                }
-
-            } else if (String(filterValue).toLowerCase() !== String(repoMethodValue).toLowerCase()) {
-                isMatch = false;
+                // filterValue needs to be a subset of repoMethodValue.
+                isMatch = (filterValue as string[]).every((filterValueEl) => {
+                    return (repoMethodValue as string[]).includes(filterValueEl);
+                });
+            } else {
+                isMatch = String(filterValue).toLowerCase() === String(repoMethodValue).toLowerCase();
             }
 
             return isMatch;
-        }, true);
+        });
     }
 
     private getMethods(methodFilter: Glue42Core.AGM.MethodDefinition): ClientMethodInfo[] {

--- a/packages/core/src/interop/client/repository.ts
+++ b/packages/core/src/interop/client/repository.ts
@@ -13,6 +13,7 @@ export default class ClientRepository {
     // each server has format {id:'', info:{}, methods:{}}
     // where methods has format {id:'', info:{}}
     private servers: { [id: string]: ServerInfo } = {};
+    private myServer: ServerInfo;
 
     // object keyed by method identifier - value is number of servers that offer that method
     private methodsCount: { [id: string]: number } = {};
@@ -20,8 +21,15 @@ export default class ClientRepository {
     // store for callbacks
     private callbacks = CallbackRegistryFactory();
 
-    constructor(private logger: Logger) {
-
+    constructor(private logger: Logger, private API: Glue42Core.AGM.API & { unwrappedInstance: InstanceWrapper }) {
+        const peerId = this.API.instance.peerId as string;
+        this.myServer = {
+            id: peerId,
+            methods: {},
+            instance: this.API.instance,
+            wrapper: this.API.unwrappedInstance,
+        };
+        this.servers[peerId] = this.myServer;
     }
 
     // add a new server to internal collection
@@ -33,7 +41,7 @@ export default class ClientRepository {
             return current.id;
         }
 
-        const wrapper = new InstanceWrapper(info);
+        const wrapper = new InstanceWrapper(this.API, info);
         const serverEntry: ServerInfo = {
             id: serverId,
             methods: {},
@@ -236,8 +244,9 @@ export default class ClientRepository {
         Object.keys(this.servers).forEach((key) => {
             this.removeServerById(key, "reset");
         });
-
-        this.servers = {};
+        this.servers = {
+            [this.myServer.id]: this.myServer
+        };
         this.methodsCount = {};
     }
 

--- a/packages/core/src/interop/instance.ts
+++ b/packages/core/src/interop/instance.ts
@@ -2,14 +2,16 @@ import generate from "shortid";
 import { Glue42Core } from "./../../glue";
 
 export class InstanceWrapper {
-    public static API: Glue42Core.AGM.API;
+    private wrapped: Glue42Core.Interop.Instance = {};
 
-    private wrapped: Glue42Core.Interop.Instance = {
-        getMethods,
-        getStreams,
-    };
+    constructor(API: Glue42Core.AGM.API, instance?: Glue42Core.AGM.Instance, connection?: Glue42Core.Connection.API) {
+        this.wrapped.getMethods = function (): Glue42Core.Interop.Method[] {
+            return API.methodsForInstance(this);
+        };
+        this.wrapped.getStreams = function (): Glue42Core.Interop.Method[] {
+            return API.methodsForInstance(this).filter((m) => m.supportsStreaming);
+        };
 
-    constructor(instance?: Glue42Core.AGM.Instance, connection?: Glue42Core.Connection.API) {
         if (instance) {
             this.refreshWrappedObject(instance);
         }
@@ -51,12 +53,4 @@ export class InstanceWrapper {
         this.wrapped.service = resolvedIdentity.service;
         this.wrapped.peerId = resolvedIdentity.peerId;
     }
-}
-
-function getMethods(this: any): Glue42Core.Interop.Method[] {
-    return InstanceWrapper.API?.methodsForInstance(this);
-}
-
-function getStreams(this: any): Glue42Core.Interop.Method[] {
-    return InstanceWrapper.API?.methodsForInstance(this).filter((m) => m.supportsStreaming);
 }

--- a/packages/core/src/interop/interop.ts
+++ b/packages/core/src/interop/interop.ts
@@ -14,6 +14,7 @@ export default class Interop implements Glue42Core.AGM.API {
 
     public client!: Client;
     public server!: Server;
+    public unwrappedInstance: InstanceWrapper;
     private protocol!: Protocol;
     private clientRepository: ClientRepository;
     private serverRepository: ServerRepository;
@@ -37,9 +38,9 @@ export default class Interop implements Glue42Core.AGM.API {
         }
 
         // Initialize our modules
-        InstanceWrapper.API = this;
-        this.instance = new InstanceWrapper(undefined, connection).unwrap();
-        this.clientRepository = new ClientRepository(configuration.logger.subLogger("cRep"));
+        this.unwrappedInstance = new InstanceWrapper(this, undefined, connection);
+        this.instance = this.unwrappedInstance.unwrap();
+        this.clientRepository = new ClientRepository(configuration.logger.subLogger("cRep"), this);
         this.serverRepository = new ServerRepository();
         let protocolPromise: Promise<Protocol>;
 

--- a/packages/core/tests/interop/methods.ts
+++ b/packages/core/tests/interop/methods.ts
@@ -188,7 +188,7 @@ describe("methods", () => {
         return Promise.resolve();
     });
 
-    it ("methods filter check", async () => {
+    it("methods filter check", async () => {
         const glue2 = await createGlue();
         const name = getMethodName();
         const objectTypes = ["1", "2"];
@@ -207,6 +207,14 @@ describe("methods", () => {
             displayName,
         };
         await glue.interop.register(method, () => {/** DO NOTHING */ });
+        await new Promise((resolve) => {
+            const unsub = glue2.interop.methodAdded((addedMethod) => {
+                if (addedMethod.name === name) {
+                    unsub();
+                    resolve();
+                }
+            });
+        });
 
         const checkMethod = (filter: any, msg: string) => {
             // tslint:disable-next-line:no-console


### PR DESCRIPTION
Short-circuit x2 frequently used `containsProps()` method
Fix a broken @glue42/core test

NOTE: Once this PR is merged un-skip and rename the Interop tests whose name includes `PR: https://github.com/Glue42/core/pull/158`.