### PR TITLE
Workspaces extensions improvements

### DIFF
--- a/packages/golden-layout/src/js/controls/Tab.js
+++ b/packages/golden-layout/src/js/controls/Tab.js
@@ -134,7 +134,7 @@ lm.utils.copy(lm.controls.Tab.prototype, {
 		if (this.contentItem.parent.header.tabs.length < 2 && this.contentItem.layoutManager.config.settings.mode === "workspace") {
 			return;
 		}
-		if (this.contentItem.layoutManager.config.settings.mode !== "workspace" && !this.contentItem.config.windowId) {
+		if (this.contentItem.layoutManager.config.settings.mode !== "workspace" && (!this.contentItem.config.windowId && !this.contentItem.componentState.windowId)) {
 			return;
 		}
 		const newProxy = new lm.controls.DragProxy(

--- a/packages/golden-layout/src/js/controls/Tab.js
+++ b/packages/golden-layout/src/js/controls/Tab.js
@@ -1,3 +1,5 @@
+const { isGetAccessor } = require("typescript");
+
 /**
  * Represents an individual tab within a Stack's header
  *
@@ -131,12 +133,18 @@ lm.utils.copy(lm.controls.Tab.prototype, {
 		if (this.contentItem.parent.isMaximized === true) {
 			this.contentItem.parent.toggleMaximise();
 		}
-		if (this.contentItem.parent.header.tabs.length < 2 && this.contentItem.layoutManager.config.settings.mode === "workspace") {
+		const isWorkspaceLayout = this.contentItem.layoutManager.config.settings.mode === "workspace";
+		const hasLessThanTwoTabs = this.contentItem.parent.header.tabs.length < 2;
+		const isMissingWindowId = !this.contentItem.config.windowId && !this.contentItem.config.componentState.windowId;
+
+		if (isWorkspaceLayout && hasLessThanTwoTabs) {
 			return;
 		}
-		if (this.contentItem.layoutManager.config.settings.mode !== "workspace" && (!this.contentItem.config.windowId && !this.contentItem.componentState.windowId)) {
+
+		if (!isWorkspaceLayout && isMissingWindowId) {
 			return;
 		}
+
 		const newProxy = new lm.controls.DragProxy(
 			x,
 			y,

--- a/packages/golden-layout/src/js/controls/Tab.js
+++ b/packages/golden-layout/src/js/controls/Tab.js
@@ -1,5 +1,3 @@
-const { isGetAccessor } = require("typescript");
-
 /**
  * Represents an individual tab within a Stack's header
  *

--- a/packages/workspaces-ui-core/assets/css/goldenlayout-base.css
+++ b/packages/workspaces-ui-core/assets/css/goldenlayout-base.css
@@ -530,7 +530,6 @@ ul {
 }
 .move_area {
   flex-grow: 1;
-  cursor: move;
 }
 .empty-container-background {
   width: 100%;

--- a/packages/workspaces-ui-react/src/defaultComponents/popups/addApplication/AddApplicationPopup.tsx
+++ b/packages/workspaces-ui-react/src/defaultComponents/popups/addApplication/AddApplicationPopup.tsx
@@ -6,7 +6,7 @@ import withGlueInstance from "../../../withGlueInstance";
 
 declare const window: Window & { glue?: any };
 
-const AddApplicationPopup: React.FC<AddApplicationPopupProps> = ({ workspaceId, boxId, hidePopup, resizePopup, glue, frameId, ...props }) => {
+const AddApplicationPopup: React.FC<AddApplicationPopupProps> = ({ workspaceId, boxId, hidePopup, resizePopup, glue, frameId, filterApps, ...props }) => {
     const [inLane, setInLane] = useState(false);
     const [parent, setParent] = useState(undefined);
     const [searchTerm, setSearchTerm] = useState("");
@@ -75,6 +75,7 @@ const AddApplicationPopup: React.FC<AddApplicationPopupProps> = ({ workspaceId, 
                             inLane={inLane}
                             parent={parent}
                             searchTerm={searchTerm}
+                            filterApps={filterApps}
                             updatePopupHeight={() => { refreshPopupHeight() }}
                         />
                     </div>

--- a/packages/workspaces-ui-react/src/defaultComponents/popups/addApplication/ApplicationsList.tsx
+++ b/packages/workspaces-ui-react/src/defaultComponents/popups/addApplication/ApplicationsList.tsx
@@ -3,10 +3,13 @@ import { ApplicationListProps } from "../../../types/internal";
 import ApplicationItem from "./ApplicationItem";
 
 const ApplicationsList: React.FC<ApplicationListProps> = ({ glue, inLane, parent, hidePopup, searchTerm, updatePopupHeight }) => {
+    const inCore = !window.glue42gd;
+    const hasFlag = (app: any) => inCore || app?.userProperties?.includeInWorkspaces;
+
     const workspacesFriendlyApps: any[] = glue.appManager.applications().filter((a: any) => !a.hidden &&
         !a.isActivity &&
         !a.isShell &&
-        (!a.type || a.type === "exe" || a.type === "window"));
+        (!a.type || a.type === "exe" || a.type === "window") && hasFlag(a));
 
     const getElementOnClick = (appName: string) => {
         return async () => {

--- a/packages/workspaces-ui-react/src/defaultComponents/popups/addApplication/ApplicationsList.tsx
+++ b/packages/workspaces-ui-react/src/defaultComponents/popups/addApplication/ApplicationsList.tsx
@@ -3,8 +3,7 @@ import { ApplicationListProps } from "../../../types/internal";
 import ApplicationItem from "./ApplicationItem";
 
 const ApplicationsList: React.FC<ApplicationListProps> = ({ glue, inLane, parent, hidePopup, searchTerm, updatePopupHeight, filterApps }) => {
-    const inCore = !window.glue42gd;
-    const hasFlag = (app: any) => inCore || (app?.userProperties?.includeInWorkspaces ?? app?.userProperties?.includeInCanvas);
+    const hasFlag = (app: any) => app?.userProperties?.includeInWorkspaces ?? app?.userProperties?.includeInCanvas;
     const defaultFilter = (a: any) => !a.hidden &&
         !a.isActivity &&
         !a.isShell &&

--- a/packages/workspaces-ui-react/src/defaultComponents/popups/addApplication/ApplicationsList.tsx
+++ b/packages/workspaces-ui-react/src/defaultComponents/popups/addApplication/ApplicationsList.tsx
@@ -2,14 +2,17 @@ import React, { useEffect } from "react";
 import { ApplicationListProps } from "../../../types/internal";
 import ApplicationItem from "./ApplicationItem";
 
-const ApplicationsList: React.FC<ApplicationListProps> = ({ glue, inLane, parent, hidePopup, searchTerm, updatePopupHeight }) => {
+const ApplicationsList: React.FC<ApplicationListProps> = ({ glue, inLane, parent, hidePopup, searchTerm, updatePopupHeight, filterApps }) => {
     const inCore = !window.glue42gd;
-    const hasFlag = (app: any) => inCore || app?.userProperties?.includeInWorkspaces;
-
-    const workspacesFriendlyApps: any[] = glue.appManager.applications().filter((a: any) => !a.hidden &&
+    const hasFlag = (app: any) => inCore || (app?.userProperties?.includeInWorkspaces ?? app?.userProperties?.includeInCanvas);
+    const defaultFilter = (a: any) => !a.hidden &&
         !a.isActivity &&
         !a.isShell &&
-        (!a.type || a.type === "exe" || a.type === "window") && hasFlag(a));
+        (!a.type || a.type === "exe" || a.type === "window") && hasFlag(a);
+
+    const filter = filterApps || defaultFilter;
+
+    const workspacesFriendlyApps: any[] = glue.appManager.applications().filter(filter);
 
     const getElementOnClick = (appName: string) => {
         return async () => {

--- a/packages/workspaces-ui-react/src/defaultComponents/popups/addApplication/ApplicationsList.tsx
+++ b/packages/workspaces-ui-react/src/defaultComponents/popups/addApplication/ApplicationsList.tsx
@@ -4,10 +4,14 @@ import ApplicationItem from "./ApplicationItem";
 
 const ApplicationsList: React.FC<ApplicationListProps> = ({ glue, inLane, parent, hidePopup, searchTerm, updatePopupHeight, filterApps }) => {
     const hasFlag = (app: any) => app?.userProperties?.includeInWorkspaces ?? app?.userProperties?.includeInCanvas;
-    const defaultFilter = (a: any) => !a.hidden &&
-        !a.isActivity &&
+    const isFromSupportedType = (a: any) => !a.type || (a.type !== "activity" &&
+        a.type !== "canvas" &&
+        a.type !== "workspaces" &&
+        a.type !== "node");
+
+    const defaultFilter = (a: any) => !a.isActivity &&
         !a.isShell &&
-        (!a.type || a.type === "exe" || a.type === "window") && hasFlag(a);
+        isFromSupportedType(a) && hasFlag(a);
 
     const filter = filterApps || defaultFilter;
 

--- a/packages/workspaces-ui-react/src/types/internal.ts
+++ b/packages/workspaces-ui-react/src/types/internal.ts
@@ -123,6 +123,7 @@ export interface AddApplicationPopupProps extends React.DetailedHTMLProps<React.
   hidePopup: () => void;
   boxId: string;
   frameId?: string;
+  filterApps?: (glueApp: any) => boolean;
 }
 
 export interface AddWorkspacePopupProps extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
@@ -171,6 +172,7 @@ export interface ApplicationListProps {
   hidePopup: () => void;
   searchTerm: string;
   updatePopupHeight: () => void;
+  filterApps?: (glueApplication: any) => boolean;
 }
 
 export interface ContainerSwitchProps {


### PR DESCRIPTION
## golden-layout fix
 - The bug was that the tabs could not be dragged in the layout

## workspaces-ui-react improvements
- Added filtering logic for the AddApplicationPopup

**This PR introduces the requirement for `customProperties.includeInWorkspaces` flag in the application definitions in order to appear in the AddApplicationPopup**