### PR TITLE
Add tests for all intents methods

### DIFF
--- a/e2e/config/gtf/app.ts
+++ b/e2e/config/gtf/app.ts
@@ -40,7 +40,7 @@ export class GtfApp implements Gtf.App {
             },
             unregister: (methodDefinition: string | Glue42Web.Interop.MethodDefinition): Promise<void> => {
                 const controlArgs: ControlArgs = {
-                    operation: "unregister",
+                    operation: "unregisterMethod",
                     params: methodDefinitionToParams(methodDefinition)
                 };
                 return this.sendControl<void>(controlArgs);
@@ -164,6 +164,16 @@ export class GtfApp implements Gtf.App {
                 };
 
                 return this.sendControl<ReturnType<Glue42Web.Intents.API['addIntentListener']>>(controlArgs);
+            },
+            unregisterIntent: (intent: string | Glue42Web.Intents.AddIntentListenerRequest): Promise<void> => {
+                const controlArgs: ControlArgs = {
+                    operation: 'unregisterIntent',
+                    params: {
+                        intent: typeof intent === "string" ? { intent } : intent
+                    }
+                };
+
+                return this.sendControl<void>(controlArgs);
             }
         };
     }

--- a/e2e/config/gtf/config.ts
+++ b/e2e/config/gtf/config.ts
@@ -49,7 +49,16 @@ export const localApplicationsConfig = [
         name: "coreSupport",
         details: {
             url: "http://localhost:4242/coreSupport/index.html"
-        }
+        },
+        intents: [
+            {
+                name: "core-intent",
+                displayName: "core-intent-displayName",
+                contexts: [
+                    "test-context"
+                ]
+            }
+        ]
     },
     {
         name: "Test",

--- a/e2e/tests/intents/API/addIntentListener.spec.js
+++ b/e2e/tests/intents/API/addIntentListener.spec.js
@@ -1,0 +1,128 @@
+describe('addIntentListener()', () => {
+    // An unsub function returned by `addIntentListener()`.
+    let unsubObj;
+
+    before(() => {
+        return coreReady;
+    });
+
+    afterEach(async () => {
+        if (typeof unsubObj !== "undefined") {
+            const intentListenerRemovedPromise = gtf.intents.waitForIntentListenerRemoved(unsubObj.intent);
+            unsubObj.unsubscribe();
+            await intentListenerRemovedPromise;
+            unsubObj = undefined;
+        }
+    });
+
+    it('Should throw an error when intent isn\'t of type string or type object.', (done) => {
+        try {
+            glue.intents.addIntentListener(42, () => { });
+
+            done('addIntentListener() should have thrown an error because intent wasn\'t of type string or object!');
+        } catch (error) {
+            expect(error.message).to.equal('expected a value matching one of the decoders, got the errors ["at error: expected a string, got a number", "at error: expected an object, got a number"]');
+
+            done();
+        }
+    });
+
+    it('Should throw an error when intent.intent isn\'t of type string.', (done) => {
+        try {
+            glue.intents.addIntentListener({ intent: 42 }, () => { });
+
+            done('addIntentListener() should have thrown an error because intent.intent wasn\'t of type string or object!');
+        } catch (error) {
+            expect(error.message).to.equal('expected a value matching one of the decoders, got the errors ["at error: expected a string, got an object", "at error.intent: expected a string, got a number"]');
+
+            done();
+        }
+    });
+
+    it('Should throw an error when handler isn\'t of type function.', (done) => {
+        try {
+            glue.intents.addIntentListener('our-intent', 42);
+
+            done('addIntentListener() should have thrown an error because handler wasn\'t of type function!');
+        } catch (error) {
+            expect(error.message).to.equal('Cannot add intent listener, because the provided handler is not a function!');
+
+            done();
+        }
+    });
+
+    it('Should invoke the handler when the intent is raised.', (done) => {
+        const intentName = 'our-intent';
+        const raiseContext = {
+            data: {
+                a: 42
+            },
+            type: 'test-context'
+        };
+        unsubObj = glue.intents.addIntentListener(intentName, (context) => {
+            try {
+                expect(context).to.eql(raiseContext);
+
+                done();
+            } catch (error) {
+                done(error);
+            }
+        });
+        unsubObj.intent = intentName;
+
+        glue.intents.raise({
+            intent: intentName,
+            context: raiseContext
+        });
+    });
+
+    it('Should return a working unsubscribe function.', (done) => {
+        const intentName = 'test-intent';
+
+        const unsub = glue.intents.addIntentListener(intentName, () => { });
+        unsub.unsubscribe();
+
+        glue.intents.raise(intentName)
+            .then(() => done(`raise() should have thrown an error because an intent with name ${intentName} shouldn't be present!`))
+            .catch((error) => {
+                try {
+                    expect(error.message).to.equal(`Internal Platform Communication Error. Attempted operation: "raiseIntent" with data: {"intent":"${intentName}"}.  -> Inner message: The platform rejected operation raiseIntent for domain: intents with reason: "Intent ${intentName} not found!"`);
+
+                    done()
+                } catch (error) {
+                    done(error);
+                }
+            });
+    });
+
+    it('Should throw an error when called twice for the same intent.', (done) => {
+        const intentName = 'test-intent';
+
+        unsubObj = glue.intents.addIntentListener(intentName, () => { });
+        unsubObj.intent = intentName;
+
+        try {
+            glue.intents.addIntentListener(intentName, () => { });
+
+            done(`addIntentListener() should have thrown an error because a listener for intent with name ${intentName} is already present!`);
+        } catch (error) {
+            expect(error.message).to.equal(`Intent listener for intent ${intentName} already registered!`);
+
+            done();
+        }
+    });
+
+    it('Should not throw an error when called twice for the same intent after unregistering the first one.', async () => {
+        const intentName = 'test-intent';
+
+        const intentListenerRemovedPromise = gtf.intents.waitForIntentListenerRemoved(intentName);
+
+        const unsub = glue.intents.addIntentListener(intentName, () => { });
+        unsub.unsubscribe();
+
+        await intentListenerRemovedPromise;
+
+        unsubObj = glue.intents.addIntentListener(intentName, () => { });
+        unsubObj.intent = intentName;
+    });
+});

--- a/e2e/tests/intents/API/find.spec.js
+++ b/e2e/tests/intents/API/find.spec.js
@@ -1,0 +1,240 @@
+describe('find()', () => {
+    // An unsub function returned by `addIntentListener()`.
+    let unsubObj;
+    let glueApplication;
+
+    before(() => {
+        return coreReady;
+    });
+
+    afterEach(async () => {
+        if (typeof unsubObj !== "undefined") {
+            const intentListenerRemovedPromise = gtf.intents.waitForIntentListenerRemoved(unsubObj.intent);
+            unsubObj.unsubscribe();
+            await intentListenerRemovedPromise;
+            unsubObj = undefined;
+        }
+        if (typeof glueApplication !== "undefined") {
+            await glueApplication.stop();
+
+            glueApplication = undefined;
+        }
+    });
+
+    it('Should throw an error when intentFilter isn\'t of type string or type object.', (done) => {
+        glue.intents.find(42)
+            .then(() => done('find() should have thrown an error because intentFilter wasn\'t of type string or object!'))
+            .catch((error) => {
+                try {
+                    expect(error.message).to.equal('expected a value matching one of the decoders, got the errors ["at error: expected a string, got a number", "at error: expected an object, got a number"]');
+
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            });
+    });
+
+    it('Should throw an error when intentFilter.name isn\'t of type string.', (done) => {
+        glue.intents.find({ name: 42 })
+            .then(() => done('find() should have thrown an error because intentFilter.name wasn\'t of type string!'))
+            .catch((error) => {
+                try {
+                    expect(error.message).to.equal('expected a value matching one of the decoders, got the errors ["at error: expected a string, got an object", "at error.name: expected a string, got a number"]');
+
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            });
+    });
+
+    it('Should return an empty array if the intent doesn\'t exist (string).', async () => {
+        expect(await glue.intents.find('non-existent-intent-name')).to.be.empty;
+    });
+
+    it('Should return an empty array if the intent doesn\'t exist (IntentFilter - name).', async () => {
+        expect(await glue.intents.find({ name: 'non-existent-intent-name' })).to.be.empty;
+    });
+
+    it('Should return an empty array if the intent doesn\'t exist (IntentFilter - contextType).', async () => {
+        expect(await glue.intents.find({ contextType: 'non-existent-context-type' })).to.be.empty;
+    });
+
+    it('Should return an app intent (string).', async () => {
+        const localAppIntentsWithAppInfo = gtf.appManager.getLocalApplications().filter((localApp) => typeof localApp.intents !== 'undefined').flatMap((localApp) => localApp.intents.map((intent) => ({ ...localApp, ...intent, applicationName: localApp.name, intentName: intent.name })));
+
+        const intentName = localAppIntentsWithAppInfo[0].name;
+
+        const allIntents = await glue.intents.all();
+        const allMatchingNameIntents = allIntents.filter((intent) => intent.name === intentName);
+
+        const foundIntents = await glue.intents.find(intentName);
+
+        expect(foundIntents).to.eql(allMatchingNameIntents);
+    });
+
+    it('Should return an instance intent registered by another party (string).', async () => {
+        const intentToRegister = {
+            intent: 'another-party-intent',
+            contextTypes: ['test-context'],
+            displayName: 'another-party-intent-displayName',
+            icon: 'another-party-intent-icon',
+            description: 'another-party-intent-description'
+        };
+
+        glueApplication = await gtf.createApp();
+        await glueApplication.intents.addIntentListener(intentToRegister);
+
+        const allIntents = await glue.intents.all();
+        const allMatchingNameIntents = allIntents.find((intent) => intent.name === intentToRegister.intent);
+
+        const foundIntents = await glue.intents.find(intentToRegister.intent);
+
+        expect(foundIntents).to.be.of.length(1);
+
+        const foundIntent = foundIntents[0];
+
+        expect(foundIntent).to.eql(allMatchingNameIntents);
+    });
+
+    it('Should return an instance intent registered by us (string).', async () => {
+        const intentName = 'our-intent';
+        const intentToRegister = {
+            intent: intentName,
+            contextTypes: ['test-context'],
+            displayName: 'our-intent-displayName',
+            icon: 'our-intent-icon',
+            description: 'our-intent-description'
+        };
+        unsubObj = glue.intents.addIntentListener(intentToRegister, () => { });
+        unsubObj.intent = intentName;
+
+        const allIntents = await glue.intents.all();
+        const allMatchingNameIntents = allIntents.find((intent) => intent.name === intentToRegister.intent);
+
+        const foundIntents = await glue.intents.find(intentToRegister.intent);
+
+        expect(foundIntents).to.be.of.length(1);
+
+        const foundIntent = foundIntents[0];
+
+        expect(foundIntent).to.eql(allMatchingNameIntents);
+    });
+
+    it('Should return an app intent (IntentFilter - name).', async () => {
+        const localAppIntentsWithAppInfo = gtf.appManager.getLocalApplications().filter((localApp) => typeof localApp.intents !== 'undefined').flatMap((localApp) => localApp.intents.map((intent) => ({ ...localApp, ...intent, applicationName: localApp.name, intentName: intent.name })));
+
+        const intentName = localAppIntentsWithAppInfo[0].name;
+
+        const allIntents = await glue.intents.all();
+        const allMatchingNameIntents = allIntents.filter((intent) => intent.name === intentName);
+
+        const foundIntents = await glue.intents.find({ name: intentName });
+
+        expect(foundIntents).to.eql(allMatchingNameIntents);
+    });
+
+    it('Should return an instance intent registered by another party (IntentFilter - name).', async () => {
+        const intentToRegister = {
+            intent: 'another-party-intent',
+            contextTypes: ['test-context'],
+            displayName: 'another-party-intent-displayName',
+            icon: 'another-party-intent-icon',
+            description: 'another-party-intent-description'
+        };
+
+        glueApplication = await gtf.createApp();
+        await glueApplication.intents.addIntentListener(intentToRegister);
+
+        const allIntents = await glue.intents.all();
+        const allMatchingNameIntents = allIntents.find((intent) => intent.name === intentToRegister.intent);
+
+        const foundIntents = await glue.intents.find({ name: intentToRegister.intent });
+
+        expect(foundIntents).to.be.of.length(1);
+
+        const foundIntent = foundIntents[0];
+
+        expect(foundIntent).to.eql(allMatchingNameIntents);
+    });
+
+    it('Should return an instance intent registered by us (IntentFilter - name).', async () => {
+        const intentName = 'our-intent';
+        const intentToRegister = {
+            intent: intentName,
+            contextTypes: ['test-context'],
+            displayName: 'our-intent-displayName',
+            icon: 'our-intent-icon',
+            description: 'our-intent-description'
+        };
+        unsubObj = glue.intents.addIntentListener(intentToRegister, () => { });
+        unsubObj.intent = intentName;
+
+        const allIntents = await glue.intents.all();
+        const allMatchingNameIntents = allIntents.find((intent) => intent.name === intentToRegister.intent);
+
+        const foundIntents = await glue.intents.find({ name: intentToRegister.intent });
+
+        expect(foundIntents).to.be.of.length(1);
+
+        const foundIntent = foundIntents[0];
+
+        expect(foundIntent).to.eql(allMatchingNameIntents);
+    });
+
+    it('Should return an app intent registered by localApplications (IntentFilter - contextType).', async () => {
+        const localAppIntentsWithContextsWithAppInfo = gtf.appManager.getLocalApplications().filter((localApp) => Array.isArray(localApp.intents) && localApp.intents.some((intent) => Array.isArray(intent.contexts) && intent.contexts.length > 0)).flatMap((localApp) => localApp.intents.map((intent) => ({ ...localApp, ...intent, applicationName: localApp.name, intentName: intent.name })));
+
+        const contextType = localAppIntentsWithContextsWithAppInfo[0].contexts[0];
+
+        const allIntents = await glue.intents.all();
+        const allMatchingContextTypeIntents = allIntents.filter((intent) => intent.handlers.some((handler) => handler.contextTypes.includes(contextType)));
+
+        const foundIntents = await glue.intents.find({ contextType });
+
+        expect(foundIntents).to.eql(allMatchingContextTypeIntents);
+    });
+
+    it('Should return an instance intent registered by another party (IntentFilter - contextType).', async () => {
+        const contextType = 'test-context';
+        const intentToRegister = {
+            intent: 'another-party-intent',
+            contextTypes: [contextType],
+            displayName: 'another-party-intent-displayName',
+            icon: 'another-party-intent-icon',
+            description: 'another-party-intent-description'
+        };
+
+        glueApplication = await gtf.createApp();
+        await glueApplication.intents.addIntentListener(intentToRegister);
+
+        const allIntents = await glue.intents.all();
+        const allMatchingContextTypeIntents = allIntents.filter((intent) => intent.handlers.some((handler) => handler.contextTypes.includes(contextType)));
+
+        const foundIntents = await glue.intents.find({ contextType });
+
+        expect(foundIntents).to.eql(allMatchingContextTypeIntents);
+    });
+
+    it('Should return an instance intent registered by us (IntentFilter - contextType).', async () => {
+        const intentName = 'our-intent';
+        const contextType = 'test-context';
+        const intentToRegister = {
+            intent: intentName,
+            contextTypes: [contextType],
+            displayName: 'our-intent-displayName',
+            icon: 'our-intent-icon',
+            description: 'our-intent-description'
+        };
+        unsubObj = glue.intents.addIntentListener(intentToRegister, () => { });
+        unsubObj.intent = intentName;
+
+        const allIntents = await glue.intents.all();
+        const allMatchingContextTypeIntents = allIntents.filter((intent) => intent.handlers.some((handler) => handler.contextTypes.includes(contextType)));
+
+        const foundIntents = await glue.intents.find({ contextType });
+
+        expect(foundIntents).to.eql(allMatchingContextTypeIntents);
+    });
+});

--- a/e2e/tests/intents/API/raise.spec.js
+++ b/e2e/tests/intents/API/raise.spec.js
@@ -1,0 +1,199 @@
+describe('raise()', () => {
+    // An unsub function returned by `addIntentListener()`.
+    let unsubObj;
+    let glueApplication;
+
+    before(() => {
+        return coreReady;
+    });
+
+    afterEach(async () => {
+        if (typeof unsubObj !== "undefined") {
+            const intentListenerRemovedPromise = gtf.intents.waitForIntentListenerRemoved(unsubObj.intent);
+            unsubObj.unsubscribe();
+            await intentListenerRemovedPromise;
+            unsubObj = undefined;
+        }
+        if (typeof glueApplication !== "undefined") {
+            await glueApplication.stop();
+
+            glueApplication = undefined;
+        }
+    });
+
+    it('Should throw an error when intentRequest isn\'t of type string or type object.', (done) => {
+        glue.intents.raise(42)
+            .then(() => done('raise() should have thrown an error because intentRequest wasn\'t of type string or object!'))
+            .catch((error) => {
+                try {
+                    expect(error.message).to.equal('expected a value matching one of the decoders, got the errors ["at error: expected a string, got a number", "at error: expected an object, got a number"]');
+
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            });
+    });
+
+    it('Should throw an error when intentRequest.name isn\'t of type string.', (done) => {
+        glue.intents.raise({ intent: 42 })
+            .then(() => done('raise() should have thrown an error because intentRequest.name wasn\'t of type string!'))
+            .catch((error) => {
+                try {
+                    expect(error.message).to.equal('expected a value matching one of the decoders, got the errors ["at error: expected a string, got an object", "at error.intent: expected a string, got a number"]');
+
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            });
+    });
+
+    it('Should raise the intent with the provided context to target app.', async () => {
+        const appName = 'coreSupport';
+        const intentName = 'core-intent';
+        const intentRequest = {
+            intent: intentName,
+            target: 'startNew',
+            context: {
+                type: 'test-context',
+                data: {
+                    a: 42
+                }
+            }
+        };
+
+        const allIntents = await glue.intents.all();
+        const intent = allIntents.find((intent) => intent.name === intentName);
+        const intentHandler = intent.handlers.find((handler) => handler.applicationName === appName && handler.type === 'app');
+
+        const intentResult = await glue.intents.raise(intentRequest);
+        const expectedHandler = {
+            ...intentHandler,
+            instanceId: intentResult.handler.instanceId
+        };
+
+        const appInstances = glue.appManager.application(appName).instances;
+        expect(appInstances).to.be.of.length(1);
+        glueApplication = appInstances[0];
+
+        expect(intentResult.request).to.eql(intentRequest);
+        expect(intentResult.handler).to.eql(expectedHandler);
+        // The coreSupport app's core-intent is setup to return the context it is raised with.
+        expect(intentResult.result).to.eql(intentRequest.context);
+    });
+
+    it('Should raise the intent with the provided context to target instance.', async () => {
+        const appTitle = 'Core Support';
+        const intentName = 'core-intent';
+        const intentListenerAddedPromise = gtf.intents.waitForIntentListenerAdded(intentName)
+
+        glueApplication = await gtf.createApp();
+
+        await intentListenerAddedPromise;
+
+        const intentRequest = {
+            intent: intentName,
+            target: 'reuse',
+            context: {
+                type: 'test-context',
+                data: {
+                    a: 42
+                }
+            }
+        };
+
+        const allIntents = await glue.intents.all();
+        const intent = allIntents.find((intent) => intent.name === intentName);
+        const intentHandler = intent.handlers.find((handler) => handler.applicationName === 'coreSupport' && handler.type === 'app');
+
+        const intentResult = await glue.intents.raise(intentRequest);
+        const expectedHandler = {
+            ...intentHandler,
+            instanceId: intentResult.handler.instanceId,
+            type: 'instance',
+            instanceTitle: appTitle
+        };
+
+        expect(intentResult.request).to.eql(intentRequest);
+        expect(intentResult.handler).to.eql(expectedHandler);
+        // The coreSupport app's core-intent is setup to return the context it is raised with.
+        expect(intentResult.result).to.eql(intentRequest.context);
+    });
+
+    it('Should raise the intent with the provided context to an application.', async () => {
+        const appName = 'coreSupport';
+        const intentName = 'core-intent';
+        const intentRequest = {
+            intent: intentName,
+            target: {
+                app: appName
+            },
+            context: {
+                type: 'test-context',
+                data: {
+                    a: 42
+                }
+            }
+        };
+
+        const allIntents = await glue.intents.all();
+        const intent = allIntents.find((intent) => intent.name === intentName);
+        const intentHandler = intent.handlers.find((handler) => handler.applicationName === appName && handler.type === 'app');
+
+        const intentResult = await glue.intents.raise(intentRequest);
+        const expectedHandler = {
+            ...intentHandler,
+            instanceId: intentResult.handler.instanceId
+        };
+
+        const appInstances = glue.appManager.application(appName).instances;
+        expect(appInstances).to.be.of.length(1);
+        glueApplication = appInstances[0];
+
+        expect(intentResult.request).to.eql(intentRequest);
+        expect(intentResult.handler).to.eql(expectedHandler);
+        // The coreSupport app's core-intent is setup to return the context it is raised with.
+        expect(intentResult.result).to.eql(intentRequest.context);
+    });
+
+    it('Should raise the intent with the provided context to an instance.', async () => {
+        const appTitle = 'Core Support';
+        const intentName = 'core-intent';
+        const intentListenerAddedPromise = gtf.intents.waitForIntentListenerAdded(intentName)
+
+        glueApplication = await gtf.createApp();
+
+        await intentListenerAddedPromise;
+
+        const intentRequest = {
+            intent: intentName,
+            target: {
+                instance: glueApplication.agm.instance.windowId
+            },
+            context: {
+                type: 'test-context',
+                data: {
+                    a: 42
+                }
+            }
+        };
+
+        const allIntents = await glue.intents.all();
+        const intent = allIntents.find((intent) => intent.name === intentName);
+        const intentHandler = intent.handlers.find((handler) => handler.applicationName === 'coreSupport' && handler.type === 'app');
+
+        const intentResult = await glue.intents.raise(intentRequest);
+        const expectedHandler = {
+            ...intentHandler,
+            instanceId: intentResult.handler.instanceId,
+            type: 'instance',
+            instanceTitle: appTitle
+        };
+
+        expect(intentResult.request).to.eql(intentRequest);
+        expect(intentResult.handler).to.eql(expectedHandler);
+        // The coreSupport app's core-intent is setup to return the context it is raised with.
+        expect(intentResult.result).to.eql(intentRequest.context);
+    });
+});


### PR DESCRIPTION
Fix an issue where `addIntentListener()` initially allows the addition of a second listener for the same intent