### PR TITLE
Adapt @glue42/fdc3 (and fdc3-demos) for Glue42 Core v2

### DIFF
--- a/docs/core/03_capabilities/99_fdc3-compliance/fdc3-compliance.md
+++ b/docs/core/03_capabilities/99_fdc3-compliance/fdc3-compliance.md
@@ -20,7 +20,7 @@ The Glue42 FDC3 library determines internally the environment it runs in (**Glue
 fdc3.addContextListener(context => console.log(`Context: ${context}.`));
 ```
 
-To provide a platform config to **an FDC3 Main application** you need to attach it to the global `window` object like so before referencing [`@glue42/fdc3`](https://www.npmjs.com/package/@glue42/fdc3):
+To provide a platform config to **an FDC3 Main application** you need to attach a `webPlatformConfig` config object to the global `window` object like so before referencing [`@glue42/fdc3`](https://www.npmjs.com/package/@glue42/fdc3):
 
 ```html
 <script>
@@ -48,7 +48,7 @@ See below how to use the different FDC3 features.
 
 The [FDC3 Intents](https://fdc3.finos.org/docs/next/intents/overview) concept enables the creation of cross-application workflows on the desktop. An application declares an Intent through configuration. An Intent specifies what action the application can execute and what data structure it can work with.
 
-To define Intents add them to the application configuration objects inside of the [Main application's](../../core-concepts/web-platform/overview/index.html) Glue42 [Web Platform](https://www.npmjs.com/package/@glue42/web-platform) config. For more details on defining applications, see the [Application Management: Application Definitions](../application-management/index.html#application_definitions) section. Intents can be configured under the `intents` top-level key of the application definition:
+To define Intents add them to the application configuration objects inside of the [Main application's config](../../core-concepts/web-platform/setup/index.html#configuration) or inside of the application definitions provided by a remote source. For more details on defining applications, see the [Application Management: Application Definitions](../application-management/index.html#application_definitions) section. Intents can be configured under the `intents` top-level key of the application definition:
 
 ```html
 <script>
@@ -90,7 +90,7 @@ To define Intents add them to the application configuration objects inside of th
 
 An [FDC3 Channel](https://fdc3.finos.org/docs/next/api/ref/Channel) is a named context object that an application can join in order to share and update context data and also be alerted when the context data changes. By [specification](https://fdc3.finos.org/docs/next/api/spec#context-channels), Channels can either be well-known system Channels or Channels created by apps. On a UI level, Channels can be represented by colors and names.
 
-To define Channels add them to the [Main application's](../../core-concepts/web-platform/overview/index.html) Glue42 [Web Platform](https://www.npmjs.com/package/@glue42/web-platform) config.
+To define Channels add them to the [Main application's config](../../core-concepts/web-platform/setup/index.html#configuration).
 
 ```html
 <script>
@@ -130,7 +130,34 @@ Glue42 Core applications can interact with FDC3 app Channels by using the [Share
 
 The goal of the [FDC3 App Directory](https://fdc3.finos.org/docs/next/app-directory/overview) REST service is to provide trusted identity for desktop apps. Application definitions are provided by one or more App Directory REST services where user entitlements and security can also be handled.
 
-*Note that the remote sources can supply both **Glue42 Core** and FDC3 application definitions. **Glue42 Core** supports for both. The only requirement for an FDC3 application definition to be usable in **Glue42 Core** is to have a valid `details.url` or a `url` top-level property in its `manifest` JSON string property.*
+To connect to remote sources of applications you need to attach a `remoteSources` config object to the global `window` object like so before referencing [`@glue42/fdc3`](https://www.npmjs.com/package/@glue42/fdc3):
+
+```html
+<script>
+    window.remoteSources = [
+        {
+            url: 'http://localhost:3001/v1/apps/search',
+            pollingInterval: 1000,
+            requestTimeout: 5000
+        }
+    ];
+</script>
+<script src="https://unpkg.com/@glue42/fdc3@latest/dist/fdc3-glue42.js"></script>
+```
+
+| Property | Description |
+|----------|-------------|
+| `url` | **Required**. The url of the remote source of application definitions. The remote source needs to follow the [FDC3 AppDirectory standard](https://github.com/finos/FDC3). The applications provided by the remote need to either be of type Glue42WebApplicationDefinition or FDC3Definition. |
+| `pollingInterval` | The polling interval for fetching application definitions from the remote source in milliseconds. Defaults to 3000. |
+| `requestTimeout` | The request timeout for fetching application definitions from the remote source in milliseconds. Defaults to 3000. |
+
+*Note: that the config object needs to be named `remoteSources`!*
+
+*Note: that any application can connect to remote sources and not only the Main application. The application definitions from all remote sources are then merged by the Main application.*
+
+*Note: that the remote sources can supply both **Glue42 Core** and FDC3 application definitions. **Glue42 Core** supports for both. The only requirement for an FDC3 application definition to be usable in **Glue42 Core** is to have a valid `details.url` or a `url` top-level property in its `manifest` JSON string property.*
+
+Alternatively you could supply the application definitions locally to the Main application by adding them to `webPlatformConfig.applications.local` (see [Intents](#Intents)).
 
 Below is an example FDC3 application definition:
 

--- a/docs/core/03_capabilities/99_fdc3-compliance/fdc3-compliance.md
+++ b/docs/core/03_capabilities/99_fdc3-compliance/fdc3-compliance.md
@@ -14,11 +14,33 @@ The [`@glue42/fdc3`](https://www.npmjs.com/package/@glue42/fdc3) library is the 
 <script src="https://unpkg.com/@glue42/fdc3@latest/dist/fdc3-glue42.js"></script>
 ```
 
-The Glue42 FDC3 library determines internally the environment it runs in (**Glue42 Core** or **Glue42 Enterprise**) and initializes the correct Glue42 library - [`@glue42/web`](https://www.npmjs.com/package/@glue42/web) in a **Glue42 Core** project. You don't need to call the `GlueWeb()` factory function. The FDC3 API entry point `fdc3` is available as a property of the global `window` object:
+The Glue42 FDC3 library determines internally the environment it runs in (**Glue42 Core** or **Glue42 Enterprise**) and initializes the correct Glue42 library. In a **Glue42 Core** project that can be either [`@glue42/web-platform`](https://www.npmjs.com/package/@glue42/web-platform) or [`@glue42/web`](https://www.npmjs.com/package/@glue42/web) depending on whether your application is [a Main application](../../core-concepts/web-platform/overview/index.html) or [a web client](../../core-concepts/web-client/overview/index.html). You don't need to call the `GlueWeb()`/`GlueWebPlatform()` factory functions yourself. The FDC3 API entry point `fdc3` is available as a property of the global `window` object:
 
 ```javascript
 fdc3.addContextListener(context => console.log(`Context: ${context}.`));
 ```
+
+To provide a platform config to **an FDC3 Main application** you need to attach it to the global `window` object like so before referencing [`@glue42/fdc3`](https://www.npmjs.com/package/@glue42/fdc3):
+
+```html
+<script>
+    window.webPlatformConfig = {
+        applications: {
+            local: [
+                ...
+            ]
+        },
+        channels: {
+            definitions: [
+                ...
+            ]
+        }
+    };
+</script>
+<script src="https://unpkg.com/@glue42/fdc3@latest/dist/fdc3-glue42.js"></script>
+```
+
+*Note: that the config object needs to be named `webPlatformConfig`!*
 
 See below how to use the different FDC3 features.
 
@@ -26,35 +48,34 @@ See below how to use the different FDC3 features.
 
 The [FDC3 Intents](https://fdc3.finos.org/docs/next/intents/overview) concept enables the creation of cross-application workflows on the desktop. An application declares an Intent through configuration. An Intent specifies what action the application can execute and what data structure it can work with.
 
-In **Glue42 Core**, Intents are defined in the application configuration objects when initializing the Glue42 [Web Platform](https://www.npmjs.com/package/@glue42/web-platform) library in the [Main application](../../core-concepts/web-platform/overview/index.html). For more details on defining applications, see the [Application Management: Application Definitions](../application-management/index.html#application_definitions) section. Intents can be configured under the `intents` top-level key of the application definition:
+To define Intents add them to the application configuration objects inside of the [Main application's](../../core-concepts/web-platform/overview/index.html) Glue42 [Web Platform](https://www.npmjs.com/package/@glue42/web-platform) config. For more details on defining applications, see the [Application Management: Application Definitions](../application-management/index.html#application_definitions) section. Intents can be configured under the `intents` top-level key of the application definition:
 
-```javascript
-import GlueWebPlatform from "@glue42/web-platform";
-
-const config = {
-    applications: {
-        local: [
-            {
-                name: "Clients",
-                details: {
-                    url: "http://localhost:4242/clients"
-                },
-                // Intent definitions.
-                intents: [
-                    {
-                        name: "ShowClientInfo",
-                        displayName: "Client Info",
-                        contexts: [
-                            "ClientName"
-                        ]
-                    }
-                ]
-            }
-        ]
-    }
-};
-
-const { glue } = await GlueWebPlatform(config);
+```html
+<script>
+    window.webPlatformConfig = {
+        applications: {
+            local: [
+                {
+                    name: "Clients",
+                    details: {
+                        url: "http://localhost:4242/clients"
+                    },
+                    // Intent definitions.
+                    intents: [
+                        {
+                            name: "ShowClientInfo",
+                            displayName: "Client Info",
+                            contexts: [
+                                "ClientName"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    };
+</script>
+<script src="https://unpkg.com/@glue42/fdc3@latest/dist/fdc3-glue42.js"></script>
 ```
 
 | Property | Description |
@@ -63,48 +84,38 @@ const { glue } = await GlueWebPlatform(config);
 | `displayName` | The human readable name of the Intent. Can be used in context menus, etc., to visualize the Intent. |
 | `contexts` | The type of predefined data structures with which the application can work (see [FDC3 Contexts](https://fdc3.finos.org/docs/next/context/overview)). |
 
-In order to be able to properly target applications with `raiseIntent()` the applications need to pass their application name to `@glue42/fdc3`. This is needed by the implementation so it can check whether there is a running instance of the targeted application or a new instance has to be started. Because the FDC3 specification doesn't specify any initialization logic, `@glue42/fdc3` relies on a global variable called `fdc3AppName` being present prior to importing `@glue42/fdc3`:
-
-```html
-<script>
-    window.fdc3AppName = "TradingView Blotter";
-</script>
-<script src="https://unpkg.com/@glue42/fdc3@latest/dist/fdc3-glue42.js"></script>
-```
-
 *For more information on using intents, see the [FDC3 Intents API](https://fdc3.finos.org/docs/next/intents/overview).*
 
 ### Channels
 
 An [FDC3 Channel](https://fdc3.finos.org/docs/next/api/ref/Channel) is a named context object that an application can join in order to share and update context data and also be alerted when the context data changes. By [specification](https://fdc3.finos.org/docs/next/api/spec#context-channels), Channels can either be well-known system Channels or Channels created by apps. On a UI level, Channels can be represented by colors and names.
 
-Channels are defined when initializing the Glue42 [Web Platform](https://www.npmjs.com/package/@glue42/web-platform) library in the [Main application](../../core-concepts/web-platform/overview/index.html):
+To define Channels add them to the [Main application's](../../core-concepts/web-platform/overview/index.html) Glue42 [Web Platform](https://www.npmjs.com/package/@glue42/web-platform) config.
 
-```javascript
-import GlueWebPlatform from "@glue42/web-platform";
-
-const config = {
-    channels: {
-        // Channel definitions.
-        definitions: [
-            {
-                name: "Red",
-                meta: {
-                    color: "red"
+```html
+<script>
+    window.webPlatformConfig = {
+        channels: {
+            // Channel definitions.
+            definitions: [
+                {
+                    name: "Red",
+                    meta: {
+                        color: "red"
+                    },
+                    data: { glue: 42 }
                 },
-                data: { glue: 42 }
-            },
-            {
-                name: "Green",
-                meta: {
-                    color: "#008000"
+                {
+                    name: "Green",
+                    meta: {
+                        color: "#008000"
+                    }
                 }
-            }
-        ]
-    }
-};
-
-const { glue } = await GlueWebPlatform(config);
+            ]
+        }
+    };
+</script>
+<script src="https://unpkg.com/@glue42/fdc3@latest/dist/fdc3-glue42.js"></script>
 ```
 
 All Glue42 Channels are available as FDC3 system Channels.
@@ -154,3 +165,9 @@ The demo consists of a Chart and a Blotter application. Searching and selecting 
 Right-clicking on an instrument inside the Blotter opens up a context menu with the intents that can be raised for the instrument. When the chart application is running it would update its context and when there are no instances of the Chart application running it will start a new instance with the given context.
 
 Use the [code of the demo](https://github.com/Glue42/fdc3-demos/tree/adapt-for-glue42) as a reference when adapting your own applications.
+
+#### Extension
+
+Inside of the demo project you will also find [a Chrome extension](https://github.com/Glue42/fdc3-demos/tree/adapt-for-glue42/extension) that auto injects `@glue42/fdc3` inside of all web pages. It can save you time from referencing the implementation inside of all of your projects and redeploying them, but also when integrating with 3rd party closed source applications.
+
+To install the extension simply follow the instructions inside of the [README.md](https://github.com/Glue42/fdc3-demos/blob/adapt-for-glue42/README.md).

--- a/packages/fdc3/package-lock.json
+++ b/packages/fdc3/package-lock.json
@@ -33,8 +33,7 @@
 		"@finos/fdc3": {
 			"version": "1.1.0-alpha.3",
 			"resolved": "https://registry.npmjs.org/@finos/fdc3/-/fdc3-1.1.0-alpha.3.tgz",
-			"integrity": "sha512-8g2q29DhDRGhgf8O5/Jfh+PX8k0wlkSarje5GmQRT8Emlaj+efwdkTqCdsUZRW0Rb/yZ/YrV9JLnPyEcPdEl2w==",
-			"dev": true
+			"integrity": "sha512-8g2q29DhDRGhgf8O5/Jfh+PX8k0wlkSarje5GmQRT8Emlaj+efwdkTqCdsUZRW0Rb/yZ/YrV9JLnPyEcPdEl2w=="
 		},
 		"@glue42/core": {
 			"version": "5.2.7",
@@ -55,6 +54,112 @@
 				"@glue42/workspaces-api": "^1.3.0",
 				"callback-registry": "^2.7.1",
 				"shortid": "2.2.8"
+			}
+		},
+		"@glue42/gateway-web": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@glue42/gateway-web/-/gateway-web-3.0.10.tgz",
+			"integrity": "sha512-6Iy1miv0FEJoDnQRHQ79a9VQNtD2X7RXHUIYsYemCvOuGTlRK56KuBIzhbjcOKf/KtBt8eUXvcXX/p7ttw7IwA=="
+		},
+		"@glue42/web": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@glue42/web/-/web-2.0.2.tgz",
+			"integrity": "sha512-xPKQWglPJ+u6SXcFRAm6oXTTPeZIBF4f/JYI38GsvkTj/n8of2FMKG+2Ei3Bni1KtW1BvX3kHC7xP3+LkxhBUQ==",
+			"requires": {
+				"@glue42/core": "^5.3.0",
+				"@glue42/desktop": "^5.4.1",
+				"@glue42/workspaces-api": "^1.4.0",
+				"callback-registry": "^2.6.0",
+				"decoder-validate": "0.0.2",
+				"idb": "^5.0.4",
+				"shortid": "^2.2.15"
+			},
+			"dependencies": {
+				"@glue42/core": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@glue42/core/-/core-5.3.0.tgz",
+					"integrity": "sha512-ZGH6w5bfBsOKouzimFCJGuhjoJ4Lap/I241KxWiLzE6aSDJRS6hbfx9In6tMhfVIErdk392Ck6jEd3I+MNnXvg==",
+					"requires": {
+						"callback-registry": "^2.7.1",
+						"shortid": "^2.2.6",
+						"ws": "7.1.2"
+					}
+				},
+				"@glue42/workspaces-api": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/@glue42/workspaces-api/-/workspaces-api-1.4.0.tgz",
+					"integrity": "sha512-L9ZFR1Njj/ZmRgeoBvD5J9jZmQ/YJ151n/7ktTYtnZGGe5wHYQL7vqXVxwYNvMoPnkOAHAFJ7hQwQzUn5KYXaQ==",
+					"requires": {
+						"@glue42/core": "^5.3.0",
+						"callback-registry": "^2.5.2",
+						"decoder-validate": "0.0.2"
+					}
+				},
+				"decoder-validate": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/decoder-validate/-/decoder-validate-0.0.2.tgz",
+					"integrity": "sha512-9BsqAH9Zq6CvlxKHkSrZrH2iYlhuhHcrh6uTnDvcsa9P5YEweEzt1ci+X/9STgSCE7b9BA7/QIiwhfUDDWmjxw=="
+				},
+				"shortid": {
+					"version": "2.2.16",
+					"resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
+					"integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
+					"requires": {
+						"nanoid": "^2.1.0"
+					}
+				}
+			}
+		},
+		"@glue42/web-platform": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@glue42/web-platform/-/web-platform-1.0.1.tgz",
+			"integrity": "sha512-uvz/0mw3lHbnAqztK+Qk/SIACx1zQA3rt8j/VybMVFx4Yl39l5Bpz2Nbhd7P/zsnZceMuVtCtNxFrVWKaaBlTQ==",
+			"requires": {
+				"@glue42/core": "^5.3.0",
+				"@glue42/desktop": "^5.4.1",
+				"@glue42/gateway-web": "3.0.10",
+				"@glue42/web": "^2.0.2",
+				"@glue42/workspaces-api": "^1.4.0",
+				"callback-registry": "^2.7.1",
+				"decoder-validate": "0.0.2",
+				"deepmerge": "^4.2.2",
+				"idb": "^5.0.7",
+				"shortid": "^2.2.15"
+			},
+			"dependencies": {
+				"@glue42/core": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@glue42/core/-/core-5.3.0.tgz",
+					"integrity": "sha512-ZGH6w5bfBsOKouzimFCJGuhjoJ4Lap/I241KxWiLzE6aSDJRS6hbfx9In6tMhfVIErdk392Ck6jEd3I+MNnXvg==",
+					"requires": {
+						"callback-registry": "^2.7.1",
+						"shortid": "^2.2.6",
+						"ws": "7.1.2"
+					}
+				},
+				"@glue42/workspaces-api": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/@glue42/workspaces-api/-/workspaces-api-1.4.0.tgz",
+					"integrity": "sha512-L9ZFR1Njj/ZmRgeoBvD5J9jZmQ/YJ151n/7ktTYtnZGGe5wHYQL7vqXVxwYNvMoPnkOAHAFJ7hQwQzUn5KYXaQ==",
+					"requires": {
+						"@glue42/core": "^5.3.0",
+						"callback-registry": "^2.5.2",
+						"decoder-validate": "0.0.2"
+					}
+				},
+				"decoder-validate": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/decoder-validate/-/decoder-validate-0.0.2.tgz",
+					"integrity": "sha512-9BsqAH9Zq6CvlxKHkSrZrH2iYlhuhHcrh6uTnDvcsa9P5YEweEzt1ci+X/9STgSCE7b9BA7/QIiwhfUDDWmjxw=="
+				},
+				"shortid": {
+					"version": "2.2.16",
+					"resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
+					"integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
+					"requires": {
+						"nanoid": "^2.1.0"
+					}
+				}
 			}
 		},
 		"@glue42/workspaces-api": {
@@ -243,8 +348,7 @@
 		"deepmerge": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-			"dev": true
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -343,6 +447,11 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
+		},
+		"idb": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/idb/-/idb-5.0.8.tgz",
+			"integrity": "sha512-K9xInRkVbT3ZsYimD2KVj6B4E93IBvOjEQTryu99WuuN7G+7x3SzA79+yubbX0QRN9V64Gi+L+ulG5QYTVydOg=="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -468,6 +577,11 @@
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
+		},
+		"nanoid": {
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+			"integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
 		},
 		"once": {
 			"version": "1.4.0",

--- a/packages/fdc3/package-lock.json
+++ b/packages/fdc3/package-lock.json
@@ -57,6 +57,112 @@
 				"shortid": "2.2.8"
 			}
 		},
+		"@glue42/gateway-web": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@glue42/gateway-web/-/gateway-web-3.0.10.tgz",
+			"integrity": "sha512-6Iy1miv0FEJoDnQRHQ79a9VQNtD2X7RXHUIYsYemCvOuGTlRK56KuBIzhbjcOKf/KtBt8eUXvcXX/p7ttw7IwA=="
+		},
+		"@glue42/web": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@glue42/web/-/web-2.0.1.tgz",
+			"integrity": "sha512-hcMndWrxQeTCNXp7gfB4HwCw4cadRBxDP5K6yhzBb5eKGyv5s6vT3Z4LIjA1r8H1xOG5yOaUC7/U6FbkSL7cww==",
+			"requires": {
+				"@glue42/core": "^5.3.0",
+				"@glue42/desktop": "^5.4.1",
+				"@glue42/workspaces-api": "^1.4.0",
+				"callback-registry": "^2.6.0",
+				"decoder-validate": "0.0.2",
+				"idb": "^5.0.4",
+				"shortid": "^2.2.15"
+			},
+			"dependencies": {
+				"@glue42/core": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@glue42/core/-/core-5.3.0.tgz",
+					"integrity": "sha512-ZGH6w5bfBsOKouzimFCJGuhjoJ4Lap/I241KxWiLzE6aSDJRS6hbfx9In6tMhfVIErdk392Ck6jEd3I+MNnXvg==",
+					"requires": {
+						"callback-registry": "^2.7.1",
+						"shortid": "^2.2.6",
+						"ws": "7.1.2"
+					}
+				},
+				"@glue42/workspaces-api": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/@glue42/workspaces-api/-/workspaces-api-1.4.0.tgz",
+					"integrity": "sha512-L9ZFR1Njj/ZmRgeoBvD5J9jZmQ/YJ151n/7ktTYtnZGGe5wHYQL7vqXVxwYNvMoPnkOAHAFJ7hQwQzUn5KYXaQ==",
+					"requires": {
+						"@glue42/core": "^5.3.0",
+						"callback-registry": "^2.5.2",
+						"decoder-validate": "0.0.2"
+					}
+				},
+				"decoder-validate": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/decoder-validate/-/decoder-validate-0.0.2.tgz",
+					"integrity": "sha512-9BsqAH9Zq6CvlxKHkSrZrH2iYlhuhHcrh6uTnDvcsa9P5YEweEzt1ci+X/9STgSCE7b9BA7/QIiwhfUDDWmjxw=="
+				},
+				"shortid": {
+					"version": "2.2.16",
+					"resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
+					"integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
+					"requires": {
+						"nanoid": "^2.1.0"
+					}
+				}
+			}
+		},
+		"@glue42/web-platform": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@glue42/web-platform/-/web-platform-1.0.0.tgz",
+			"integrity": "sha512-UwrqR8FoeiFEEiw7DuWQqYs0AH432HHur2KtpKm6nzfUCyZKcAPzhvjJufo4Otuj/SiosQ+LY6jsiD1GmSI+wA==",
+			"requires": {
+				"@glue42/core": "^5.3.0",
+				"@glue42/desktop": "^5.4.1",
+				"@glue42/gateway-web": "3.0.10",
+				"@glue42/web": "^2.0.1",
+				"@glue42/workspaces-api": "^1.4.0",
+				"callback-registry": "^2.7.1",
+				"decoder-validate": "0.0.2",
+				"deepmerge": "^4.2.2",
+				"idb": "^5.0.7",
+				"shortid": "^2.2.15"
+			},
+			"dependencies": {
+				"@glue42/core": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@glue42/core/-/core-5.3.0.tgz",
+					"integrity": "sha512-ZGH6w5bfBsOKouzimFCJGuhjoJ4Lap/I241KxWiLzE6aSDJRS6hbfx9In6tMhfVIErdk392Ck6jEd3I+MNnXvg==",
+					"requires": {
+						"callback-registry": "^2.7.1",
+						"shortid": "^2.2.6",
+						"ws": "7.1.2"
+					}
+				},
+				"@glue42/workspaces-api": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/@glue42/workspaces-api/-/workspaces-api-1.4.0.tgz",
+					"integrity": "sha512-L9ZFR1Njj/ZmRgeoBvD5J9jZmQ/YJ151n/7ktTYtnZGGe5wHYQL7vqXVxwYNvMoPnkOAHAFJ7hQwQzUn5KYXaQ==",
+					"requires": {
+						"@glue42/core": "^5.3.0",
+						"callback-registry": "^2.5.2",
+						"decoder-validate": "0.0.2"
+					}
+				},
+				"decoder-validate": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/decoder-validate/-/decoder-validate-0.0.2.tgz",
+					"integrity": "sha512-9BsqAH9Zq6CvlxKHkSrZrH2iYlhuhHcrh6uTnDvcsa9P5YEweEzt1ci+X/9STgSCE7b9BA7/QIiwhfUDDWmjxw=="
+				},
+				"shortid": {
+					"version": "2.2.16",
+					"resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
+					"integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
+					"requires": {
+						"nanoid": "^2.1.0"
+					}
+				}
+			}
+		},
 		"@glue42/workspaces-api": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@glue42/workspaces-api/-/workspaces-api-1.3.0.tgz",
@@ -243,8 +349,7 @@
 		"deepmerge": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-			"dev": true
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -343,6 +448,11 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
+		},
+		"idb": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/idb/-/idb-5.0.8.tgz",
+			"integrity": "sha512-K9xInRkVbT3ZsYimD2KVj6B4E93IBvOjEQTryu99WuuN7G+7x3SzA79+yubbX0QRN9V64Gi+L+ulG5QYTVydOg=="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -468,6 +578,11 @@
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
+		},
+		"nanoid": {
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+			"integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
 		},
 		"once": {
 			"version": "1.4.0",

--- a/packages/fdc3/package.json
+++ b/packages/fdc3/package.json
@@ -30,7 +30,8 @@
     "license": "MIT",
     "dependencies": {
         "@glue42/desktop": "^5.4.1",
-        "@glue42/web": "^2.0.0-beta.0"
+        "@glue42/web": "^2.0.1",
+        "@glue42/web-platform": "^1.0.0"
     },
     "devDependencies": {
         "@finos/fdc3": "^1.1.0-alpha.3",

--- a/packages/fdc3/package.json
+++ b/packages/fdc3/package.json
@@ -29,12 +29,12 @@
     },
     "license": "MIT",
     "dependencies": {
+        "@finos/fdc3": "^1.1.0-alpha.3",
         "@glue42/desktop": "^5.4.1",
         "@glue42/web": "^2.0.2",
         "@glue42/web-platform": "^1.0.1"
     },
     "devDependencies": {
-        "@finos/fdc3": "^1.1.0-alpha.3",
         "@rollup/plugin-commonjs": "^14.0.0",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^8.4.0",

--- a/packages/fdc3/src/main.ts
+++ b/packages/fdc3/src/main.ts
@@ -1,12 +1,12 @@
 import createDesktopAgent from "./agent";
 import Glue, { Glue42 } from "@glue42/desktop";
-import GlueWebFactory, { Glue42Web } from "@glue42/web";
-import { isGlue42Core, waitFor } from "./utils";
+import { Glue42Web } from "@glue42/web";
+import { isGlue42Core, waitFor, fetchTimeout } from "./utils";
 import { version } from "../package.json";
 import { WindowType } from "./types/windowtype";
-import { DesktopAgent } from "@finos/fdc3";
 import { Glue42GD, Glue42GDOriginalGlue } from "./types/glue42gd";
-import WebPlatformFactory from "@glue42/web-platform";
+import WebPlatformFactory, { Glue42WebPlatform } from "@glue42/web-platform";
+import { Glue42FDC3DesktopAgent } from "./types/glue42FDC3DesktopAgent";
 
 const validateGlue = (glue: Glue42.Glue | Glue42Web.API): void => {
     const apisFDC3ReliesUpon: ["contexts", "intents", "channels", "agm", "appManager"] = [
@@ -33,19 +33,15 @@ const resolveGlue = (glue: Glue42.Glue | Glue42Web.API): Glue42.Glue | Glue42Web
 
 const setupGlue42Core = (): void => {
     const webPlatformConfig = (window as WindowType).webPlatformConfig;
+    const webClientConfig: Glue42WebPlatform.Config = {
+        clientOnly: true
+    };
     const isPlatform = typeof webPlatformConfig !== "undefined";
 
-    if (isPlatform) {
-        (window as WindowType).fdc3GluePromise = WebPlatformFactory(webPlatformConfig)
-            .then(({ glue }) => {
-                return resolveGlue(glue);
-            });
-    } else {
-        (window as WindowType).fdc3GluePromise = GlueWebFactory()
-            .then((glue) => {
-                return resolveGlue(glue);
-            });
-    }
+    (window as WindowType).fdc3GluePromise = WebPlatformFactory(isPlatform ? webPlatformConfig : webClientConfig)
+        .then(({ glue }) => {
+            return resolveGlue(glue);
+        });
 };
 
 const setupGlue42Enterprise = (): void => {
@@ -85,8 +81,39 @@ const setupGlue = (): void => {
     }
 };
 
-const fdc3Factory = (): DesktopAgent & { version: string } => {
+const connectToRemoteSources = (): void => {
+    if (isGlue42Core) {
+        (window as WindowType).fdc3GluePromise.then(() => {
+            const validRemoteSources = (window as WindowType).remoteSources?.filter((remoteSource) => typeof remoteSource.url === "string" && remoteSource.url !== "") || [];
+
+            for (const remoteSource of validRemoteSources) {
+                const DEFAULT_POLLING_INTERVAL = 3000;
+                const DEFAULT_REQUEST_TIMEOUT = 3000;
+
+                const url = remoteSource.url;
+
+                const appsFetch = async (): Promise<void> => {
+                    const response = await fetchTimeout(url, remoteSource.requestTimeout || DEFAULT_REQUEST_TIMEOUT);
+                    const json = (await response.json()) as { message: string; applications: Array<Glue42Web.AppManager.Definition | Glue42WebPlatform.Applications.FDC3Definition> };
+
+                    if (json.message === "OK") {
+                        // Import also works with FDC3Definitions even though the typings say otherwise.
+                        ((window as WindowType).glue as Glue42Web.API).appManager.import?.((json.applications as Array<Glue42Web.AppManager.Definition>), "merge");
+                    }
+                };
+
+                setInterval(() => appsFetch().catch(console.warn), remoteSource.pollingInterval || DEFAULT_POLLING_INTERVAL);
+            }
+        });
+    } else {
+        console.warn("The app definitions from the remoteSource are only fetched when running inside of Glue42 Core. Please refer to the G4E documentation (https://docs.glue42.com/getting-started/fdc3-compliance/index.html#fdc3_for_glue42_enterprise-app_directory).");
+    }
+};
+
+const fdc3Factory = (): Glue42FDC3DesktopAgent => {
     setupGlue();
+
+    connectToRemoteSources();
 
     const agentApi = createDesktopAgent();
 

--- a/packages/fdc3/src/main.ts
+++ b/packages/fdc3/src/main.ts
@@ -6,13 +6,7 @@ import { version } from "../package.json";
 import { WindowType } from "./types/windowtype";
 import { DesktopAgent } from "@finos/fdc3";
 import { Glue42GD, Glue42GDOriginalGlue } from "./types/glue42gd";
-
-const defaultGlueConfig = {
-    application: (window as WindowType).fdc3AppName,
-    context: true,
-    channels: true,
-    agm: true
-};
+import WebPlatformFactory from "@glue42/web-platform";
 
 const validateGlue = (glue: Glue42.Glue | Glue42Web.API): void => {
     const apisFDC3ReliesUpon: ["contexts", "intents", "channels", "agm", "appManager"] = [
@@ -38,10 +32,20 @@ const resolveGlue = (glue: Glue42.Glue | Glue42Web.API): Glue42.Glue | Glue42Web
 };
 
 const setupGlue42Core = (): void => {
-    (window as WindowType).fdc3GluePromise = GlueWebFactory()
-        .then((glue) => {
-            return resolveGlue(glue);
-        });
+    const webPlatformConfig = (window as WindowType).webPlatformConfig;
+    const isPlatform = typeof webPlatformConfig !== "undefined";
+
+    if (isPlatform) {
+        (window as WindowType).fdc3GluePromise = WebPlatformFactory(webPlatformConfig)
+            .then(({ glue }) => {
+                return resolveGlue(glue);
+            });
+    } else {
+        (window as WindowType).fdc3GluePromise = GlueWebFactory()
+            .then((glue) => {
+                return resolveGlue(glue);
+            });
+    }
 };
 
 const setupGlue42Enterprise = (): void => {
@@ -55,7 +59,7 @@ const setupGlue42Enterprise = (): void => {
                 const GlueFactory = (window as WindowType).Glue || Glue;
 
                 return GlueFactory({
-                    ...defaultGlueConfig,
+                    channels: true,
                     appManager: "full"
                 });
             } else {

--- a/packages/fdc3/src/types/glue42FDC3DesktopAgent.d.ts
+++ b/packages/fdc3/src/types/glue42FDC3DesktopAgent.d.ts
@@ -1,0 +1,5 @@
+import { DesktopAgent } from "@finos/fdc3";
+
+export type Glue42FDC3DesktopAgent = DesktopAgent & {
+  version: string;
+};

--- a/packages/fdc3/src/types/remoteSource.d.ts
+++ b/packages/fdc3/src/types/remoteSource.d.ts
@@ -1,0 +1,18 @@
+export type RemoteSource = {
+  /**
+   * The url of the remote source of application definitions. The remote source needs to follow the [FDC3 AppDirectory standard](https://github.com/finos/FDC3). The applications provided by the remote need to either be of type Glue42WebApplicationDefinition or FDC3Definition.
+   */
+  url: string;
+
+  /**
+   * The polling interval for fetching application definitions from the remote source in milliseconds.
+   * @default 3000
+   */
+  pollingInterval?: number;
+
+  /**
+   * The request timeout for fetching application definitions from the remote source in milliseconds.
+   * @default 3000
+   */
+  requestTimeout?: number;
+};

--- a/packages/fdc3/src/types/windowtype.d.ts
+++ b/packages/fdc3/src/types/windowtype.d.ts
@@ -2,13 +2,13 @@ import { Glue42 } from "@glue42/desktop";
 import { Glue42Web } from "@glue42/web";
 import { Glue42GD } from "./glue42gd";
 import { DesktopAgent } from "@finos/fdc3";
+import { Glue42WebPlatform } from "@glue42/web-platform";
 
 export type WindowType = (typeof window) & {
   glue: Glue42.Glue | Glue42Web.API;
   fdc3GluePromise: Promise<void | Glue42.Glue | Glue42Web.API>;
-  // TODO: Fix once the Glue42.GDObject typings are updated.
   glue42gd?: Glue42GD;
-  fdc3AppName?: string;
+  webPlatformConfig?: Glue42WebPlatform.Config;
   Glue?: (config?: Glue42.Config) => Promise<Glue42.Glue>;
   fdc3?: DesktopAgent;
 }

--- a/packages/fdc3/src/types/windowtype.d.ts
+++ b/packages/fdc3/src/types/windowtype.d.ts
@@ -1,14 +1,16 @@
 import { Glue42 } from "@glue42/desktop";
 import { Glue42Web } from "@glue42/web";
 import { Glue42GD } from "./glue42gd";
-import { DesktopAgent } from "@finos/fdc3";
 import { Glue42WebPlatform } from "@glue42/web-platform";
+import { Glue42FDC3DesktopAgent } from "./glue42FDC3DesktopAgent";
+import { RemoteSource } from "./remoteSource";
 
 export type WindowType = (typeof window) & {
   glue: Glue42.Glue | Glue42Web.API;
   fdc3GluePromise: Promise<void | Glue42.Glue | Glue42Web.API>;
   glue42gd?: Glue42GD;
   webPlatformConfig?: Glue42WebPlatform.Config;
+  remoteSources?: Array<RemoteSource>;
   Glue?: (config?: Glue42.Config) => Promise<Glue42.Glue>;
-  fdc3?: DesktopAgent;
-}
+  fdc3?: Glue42FDC3DesktopAgent;
+};

--- a/packages/fdc3/types.d.ts
+++ b/packages/fdc3/types.d.ts
@@ -1,1 +1,3 @@
 export * from "@finos/fdc3";
+export * from "./src/types/glue42FDC3DesktopAgent";
+export * from "./src/types/windowType";


### PR DESCRIPTION
Update the documentation
Fix an issue where `addIntentListener()` and `raiseIntent()` used the FDC3 Context type instead of the Glue42 one