### PR TITLE
Change flags to be a string => any mapping (instead of string => string)

### DIFF
--- a/e2e/tests/interop/API/methodAdded.spec.js
+++ b/e2e/tests/interop/API/methodAdded.spec.js
@@ -230,12 +230,14 @@ describe('methodAdded()', () => {
             'getServers',
             'name',
             'objectTypes',
+            'flags',
             'returns',
             'supportsStreaming',
         ];
 
         const fullMethodOptions = {
             objectTypes: ['otherApp'],
+            flags: { a: 'test', b: true, c: 42, d: ['43'], e: { f: 44 }, g: { h: { i: '45' } } },
             description: 'same description',
             displayName: 'awesome display name',
             accepts: 'String name',
@@ -345,6 +347,7 @@ describe('methodAdded()', () => {
             'getServers',
             'name',
             'objectTypes',
+            'flags',
             'returns',
             'supportsStreaming',
         ];

--- a/e2e/tests/interop/API/methodRemoved.spec.js
+++ b/e2e/tests/interop/API/methodRemoved.spec.js
@@ -280,6 +280,7 @@ describe('methodRemoved()', () => {
             'getServers',
             'name',
             'objectTypes',
+            'flags',
             'returns',
             'supportsStreaming',
         ];
@@ -287,6 +288,7 @@ describe('methodRemoved()', () => {
         const fullMethodOptions = {
             name: '',
             objectTypes: ['otherApp'],
+            flags: { a: 'test', b: true, c: 42, d: ['43'], e: { f: 44 }, g: { h: { i: '45' } } },
             description: 'same description',
             displayName: 'awesome display name',
             accepts: 'String name',
@@ -413,6 +415,7 @@ describe('methodRemoved()', () => {
             'getServers',
             'name',
             'objectTypes',
+            'flags',
             'returns',
             'supportsStreaming',
         ];

--- a/e2e/tests/interop/API/subscribe.spec.js
+++ b/e2e/tests/interop/API/subscribe.spec.js
@@ -21,6 +21,8 @@ describe('subscribe()', () => {
         glueApplicationTwo = null;
 
         myStreams = [];
+
+        await Promise.all(promisesToAwait);
     });
 
     describe('for single-server-stream', () => {

--- a/e2e/tests/interop/Instance/getMethods.spec.js
+++ b/e2e/tests/interop/Instance/getMethods.spec.js
@@ -25,14 +25,14 @@ describe('getMethods()', () => {
         return gtf.agm.unregisterAllMyNonSystemMethods();
     });
 
-    it.skip('Should return the same count of method like .methodsForInstance. | PR: https://github.com/Glue42/core/pull/158', async () => {
+    it('Should return the same count of method like .methodsForInstance.', async () => {
         const getMethodResult = glue.interop.instance.getMethods();
         const methodResult = glue.interop.methodsForInstance(glue.interop.instance);
 
         expect(getMethodResult.length).to.equal(methodResult.length);
     });
 
-    it.skip('Should return all methods registered by that instance. | PR: https://github.com/Glue42/core/pull/158', async () => {
+    it('Should return all methods registered by that instance.', async () => {
         const allMethods = glue.interop.instance.getMethods();
         expect([name1, name2, name3].every(myName => allMethods.some((сMethod) => сMethod.name === myName))).to.equal(true);
     });

--- a/e2e/tests/interop/Instance/getStreams.spec.js
+++ b/e2e/tests/interop/Instance/getStreams.spec.js
@@ -26,7 +26,7 @@ describe('getStreams()', () => {
         myStreams = [];
     });
 
-    it.skip('Should return the same count of method like .methodsForInstance. | PR: https://github.com/Glue42/core/pull/158', async () => {
+    it('Should return the same count of method like .methodsForInstance.', async () => {
         const getMethodResult = glue.interop.instance.getStreams();
         const methodResult = glue.interop.methodsForInstance(glue.interop.instance).filter(m => m.supportsStreaming);
 
@@ -34,7 +34,7 @@ describe('getStreams()', () => {
     });
 
 
-    it.skip('Should return all streams registered by that instance. | PR: https://github.com/Glue42/core/pull/158', (done) => {
+    it('Should return all streams registered by that instance.', (done) => {
         try {
             const allStreams = glue.interop.instance.getStreams();
             expect([name1, name2, name3].every(myName => allStreams.some(serverS => serverS.name === myName))).to.equal(true);

--- a/packages/core/glue.d.ts
+++ b/packages/core/glue.d.ts
@@ -796,7 +796,7 @@ export namespace Glue42Core {
             supportsStreaming?: boolean;
 
             /** Optional flags attached to the method */
-            flags?: { [key: string]: string };
+            flags?: { [key: string]: any };
 
             /** Returns all servers that provide the method. */
             getServers?(): Instance[];
@@ -833,7 +833,7 @@ export namespace Glue42Core {
             supportsStreaming: boolean;
 
             /** Optional flags attached to the method */
-            flags: { [key: string]: string };
+            flags: { [key: string]: any };
 
             /** Returns all servers that provide the method. */
             getServers(): Instance[];

--- a/packages/core/src/contexts/helpers.ts
+++ b/packages/core/src/contexts/helpers.ts
@@ -194,6 +194,15 @@ export function setValueToPath(obj: any, value: any, path: string) {
     obj[pathArr[i]] = value;
 }
 
+export function isSubset(superObj: any, subObj: any): boolean {
+    return Object.keys(subObj).every((ele) => {
+        if (typeof subObj[ele] === "object") {
+            return isSubset(superObj?.[ele] || {}, subObj[ele] || {});
+        }
+        return subObj[ele] === superObj?.[ele];
+    });
+}
+
 function deletePath(obj: any, path: string) {
     const pathArr = path.split(".");
     let i;

--- a/packages/core/src/interop/protocols/gw3/server.ts
+++ b/packages/core/src/interop/protocols/gw3/server.ts
@@ -34,7 +34,7 @@ export default class ServerProtocol implements ServerProtocolDefinition {
 
     public register(repoMethod: ServerMethodInfo, isStreaming?: boolean): Promise<void> {
         const methodDef = repoMethod.definition;
-        const flags = Object.assign({}, methodDef.flags ?? {}, { streaming: isStreaming || false });
+        const flags = Object.assign({}, { metadata: methodDef.flags ?? {} }, { streaming: isStreaming || false });
 
         const registerMsg: RegisterMethodMessage = {
             type: "register",

--- a/packages/core/src/interop/server/stream.ts
+++ b/packages/core/src/interop/server/stream.ts
@@ -50,7 +50,7 @@ export default class ServerStream implements Glue42Core.AGM.Stream {
             objectTypes: def2.objectTypes,
             returns: def2.returns,
             supportsStreaming: def2.supportsStreaming,
-            flags: def2.flags,
+            flags: def2.flags?.metadata,
         };
     }
 

--- a/packages/web-platform/src/libs/intents/controller.ts
+++ b/packages/web-platform/src/libs/intents/controller.ts
@@ -112,15 +112,7 @@ export class IntentsController implements LibController {
                     intents[intentName] = [];
                 }
 
-                let info: Glue42Web.Intents.AddIntentListenerRequest | undefined;
-
-                if (method.description) {
-                    try {
-                        info = JSON.parse(method.description);
-                    } catch {
-                        this.logger?.trace(`[${commandId}] Parsing method ${method.name}'s description failed!`);
-                    }
-                }
+                const info = method.flags as Glue42Web.Intents.AddIntentListenerRequest;
 
                 const app = apps.find((appDef) => appDef.name === server.application);
                 let appIntent: IntentInfo | undefined;
@@ -139,11 +131,11 @@ export class IntentsController implements LibController {
                     // IFrames do not have windowIds but can still register intents.
                     instanceId: server.windowId || server.instance,
                     applicationName: server.application || "",
-                    applicationIcon: info?.icon || app?.icon,
+                    applicationIcon: info.icon || app?.icon,
                     applicationTitle: app?.title || "",
-                    applicationDescription: info?.description || app?.caption,
-                    displayName: info?.displayName || appIntent?.displayName,
-                    contextTypes: info?.contextTypes || appIntent?.contexts,
+                    applicationDescription: info.description || app?.caption,
+                    displayName: info.displayName || appIntent?.displayName,
+                    contextTypes: info.contextTypes || appIntent?.contexts,
                     instanceTitle: title,
                     type: "instance"
                 };

--- a/packages/web/src/intents/controller.ts
+++ b/packages/web/src/intents/controller.ts
@@ -114,9 +114,9 @@ export class IntentsController implements LibController {
                 }
             }
         };
-        const methodDescription = typeof intent === "string" ? undefined : JSON.stringify(intent);
+        const flags = typeof intent === "string" ? { intent } : intent;
 
-        this.interop.register({ name: methodName, description: methodDescription }, (args: Glue42Web.Intents.IntentContext) => {
+        this.interop.register({ name: methodName, flags }, (args: Glue42Web.Intents.IntentContext) => {
             if (subscribed) {
                 return handler(args);
             }


### PR DESCRIPTION
Nest the client flags inside of a `metadata` flag
Update `containsProps()` to consider the flags when filtering using `methods()` and `servers()`
Update the Intents API to use the flags instead of the description to store Intent metadata
Add Interop e2e tests for flags
Unskip tests related to #158
Correctly clean up inside of the `subscribe()` tests