### PR TITLE
Implement reuse workspace id

### DIFF
--- a/e2e/config/apps/noGlueApp/index.html
+++ b/e2e/config/apps/noGlueApp/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>No Glue App</title>
+</head>
+
+<body>
+    <h1>No Glue App</h1>
+</body>
+
+</html>

--- a/e2e/tests/workspaces/API/createWorkspace.spec.js
+++ b/e2e/tests/workspaces/API/createWorkspace.spec.js
@@ -275,7 +275,7 @@ describe('createWorkspace() ', function () {
                 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
                 const createPromises = [];
-                
+
                 for (const _ of Array.from({ length: 10 })) {
                     const createPromise = glue.workspaces.createWorkspace(basicConfig);
                     createPromises.push(createPromise);
@@ -284,13 +284,13 @@ describe('createWorkspace() ', function () {
 
                 await Promise.all(createPromises);
             });
-    
+
             it(`should resolve when 10 workspaces are opened in ${interval}ms intervals with newFrame setting and there should be 10 frames`, async () => {
                 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
                 const createConfig = Object.assign({}, basicConfig, { frame: { newFrame: true } });
 
                 const createPromises = [];
-                
+
                 for (const _ of Array.from({ length: 10 })) {
                     const createPromise = glue.workspaces.createWorkspace(createConfig);
                     createPromises.push(createPromise);
@@ -306,6 +306,334 @@ describe('createWorkspace() ', function () {
 
         });
 
+    });
+
+    describe('reuseWorkspaceId Should ', () => {
+        // BASIC
+        const basicConfig = {
+            children: [
+                {
+                    type: "row",
+                    children: [
+                        {
+                            type: "window",
+                            appName: "dummyApp"
+                        }
+                    ]
+                }
+            ]
+        };
+
+        const secondBasicConfig = {
+            children: [
+                {
+                    type: "group",
+                    children: [
+                        {
+                            type: "window",
+                            appName: "dummyApp"
+                        },
+                        {
+                            type: "window",
+                            appName: "dummyApp"
+                        }
+                    ]
+                }
+            ]
+        }
+
+        const context = {
+            test: "window context"
+        };
+
+        const basicConfigWithContext = {
+            children: [
+                {
+                    type: "row",
+                    children: [
+                        {
+                            type: "window",
+                            context,
+                            appName: "GTF_Glue_Isolated_Support"
+                        }
+                    ]
+                }
+            ]
+        };
+        it("resolve with a worksapce instance when noTabHeaderIs true", async () => {
+            const workspace = await glue.workspaces.createWorkspace(Object.assign({}, basicConfig, { config: { noTabHeader: true } }));
+
+            expect(workspace.constructor.name).to.eql("Workspace");
+        });
+
+        it("change noTabHeader to true when the new workspace has noTabHeader:true and target one has false", async () => {
+            const workspace = await glue.workspaces.createWorkspace(Object.assign({}, basicConfig, {
+                config: {
+                    noTabHeader: false
+                }
+            }));
+
+            const secondWorkspace = await glue.workspaces.createWorkspace(Object.assign({}, secondBasicConfig, {
+                config: {
+                    reuseWorkspaceId: workspace.id,
+                    noTabHeader: true
+                }
+            }));
+
+            const secondWorkspaceWindows = secondWorkspace.getAllWindows();
+            expect(secondWorkspaceWindows.length).to.eql(2);
+            // TODO assert correctly
+        });
+
+        it("change noTabHeader to false when the new workspaces has noTabHeader:false and target one has true", async () => {
+            const workspace = await glue.workspaces.createWorkspace(Object.assign({}, basicConfig, {
+                config: {
+                    noTabHeader: true
+                }
+            }));
+
+            const secondWorkspace = await glue.workspaces.createWorkspace(Object.assign({}, secondBasicConfig, {
+                config: {
+                    reuseWorkspaceId: workspace.id,
+                    noTabHeader: false
+                }
+            }));
+
+            const secondWorkspaceWindows = secondWorkspace.getAllWindows();
+            expect(secondWorkspaceWindows.length).to.eql(2);
+            // TODO assert correctly
+        });
+
+        Array.from({ length: 10 }).forEach((_, i) => {
+            it(`reuse the same workspace ${i + 1} times succesfully`, async () => {
+                const workspaceToBeReused = await glue.workspaces.createWorkspace(basicConfig);
+
+                await Array.from({ length: i + 1 }).reduce(async (acc, _, i2) => {
+                    await acc;
+                    const configToUseForReplacing = {
+                        children: [
+                            {
+                                type: "group",
+                                children: Array.from({ length: i2 + 1 }).map(() => ({
+                                    type: "window",
+                                    appName: "dummyApp"
+                                }))
+                            }
+                        ],
+                        config: {
+                            reuseWorkspaceId: workspaceToBeReused.id
+                        }
+                    };
+
+                    const newWorkspace = await glue.workspaces.createWorkspace(configToUseForReplacing);
+                    const windowsInNewWorkspace = newWorkspace.getAllWindows();
+
+                    expect(windowsInNewWorkspace.length).to.eql(i2 + 1);
+                }, Promise.resolve());
+            });
+        });
+
+        it('not add a new workspace in the summaries collection after resolve', async () => {
+            const workspace = await glue.workspaces.createWorkspace(basicConfig);
+            const allWorkspacesBeforeReuse = await glue.workspaces.getAllWorkspacesSummaries();
+
+            const secondWorkspаce = await glue.workspaces.createWorkspace(Object.assign({}, secondBasicConfig, {
+                config: {
+                    reuseWorkspaceId: workspace.id
+                }
+            }));
+
+            const allWorkspacesAfterReuse = await glue.workspaces.getAllWorkspacesSummaries();
+
+            expect(allWorkspacesAfterReuse.some((wsp) => wsp.id === workspace.id)).to.be.true;
+            expect(allWorkspacesAfterReuse.length).to.eql(allWorkspacesBeforeReuse.length);
+        });
+
+        it('preserve the id', async () => {
+            const workspace = await glue.workspaces.createWorkspace(basicConfig);
+            const secondWorkspаce = await glue.workspaces.createWorkspace(Object.assign({}, secondBasicConfig, {
+                config: {
+                    reuseWorkspaceId: workspace.id
+                }
+            }));
+
+            expect(workspace.id).to.eql(secondWorkspаce.id);
+        });
+
+        it('increase the number of windows by one when the reused workspace has one app less', async () => {
+            const workspace = await glue.workspaces.createWorkspace(basicConfig);
+            await Promise.all(workspace.getAllWindows().map(w => w.forceLoad()));
+            await gtf.wait(3000);
+            const windowsCount = glue.windows.list().length;
+            const secondWorkspаce = await glue.workspaces.createWorkspace(Object.assign({}, secondBasicConfig, {
+                config: {
+                    reuseWorkspaceId: workspace.id
+                }
+            }));
+
+            await Promise.all(secondWorkspаce.getAllWindows().map(w => w.forceLoad()));
+            await gtf.wait(3000);
+            const secondWindowsCount = glue.windows.list().length;
+            expect(windowsCount + 1).to.eql(secondWindowsCount);
+        });
+
+        it("preserve the context when a new context has not been passed", async () => {
+            const firstContext = {
+                "a": "b"
+            };
+
+            const workspace = await glue.workspaces.createWorkspace(Object.assign({}, basicConfig, {
+                context: firstContext
+            }));
+
+            const secondWorkspaceContext = await workspace.getContext();
+
+            const secondWorkspace = await glue.workspaces.createWorkspace(Object.assign({}, basicConfig, {
+                config: {
+                    reuseWorkspaceId: workspace.id
+                }
+            }));
+
+
+            expect(secondWorkspaceContext).to.eql(firstContext);
+        });
+
+        it("set the context correctly when a new context has been passed", async () => {
+            const firstContext = {
+                "a": "b"
+            };
+
+            const secondContext = {
+                "c": "d"
+            };
+
+            const workspace = await glue.workspaces.createWorkspace(Object.assign({}, basicConfig, {
+                context: firstContext
+            }));
+
+            const secondWorkspace = await glue.workspaces.createWorkspace(Object.assign({}, basicConfig, {
+                config: {
+                    reuseWorkspaceId: workspace.id,
+                },
+                context: secondContext
+
+            }));
+
+            const secondWorkspaceContext = await secondWorkspace.getContext();
+
+            expect(secondWorkspaceContext).to.eql(secondContext);
+        });
+
+        it('reject and not open a workspace when called with no data', (done) => {
+            glue.workspaces.createWorkspace()
+                .then(() => {
+                    done('Should not have resolved, because the method is called with no arguments');
+                })
+                .catch(() => {
+                    return glue.workspaces.getAllWorkspacesSummaries();
+                })
+                .then((summaries) => {
+                    expect(summaries.length).to.eql(0);
+                    done();
+                })
+                .catch((err) => {
+                    done(err);
+                });
+        });
+
+        it('not trigger workspace opened', (done) => {
+            let unSubFunc;
+            let workspace;
+
+            glue.workspaces.createWorkspace(basicConfig).then((w) => {
+                workspace = w;
+                return glue.workspaces.onWorkspaceOpened(() => {
+                    try {
+                        done("Should not be invoked");
+
+                        unSubFunc();
+                    } catch (error) { }
+                });
+            }).then((unSub) => {
+                unSubFunc = unSub;
+                return glue.workspaces.createWorkspace(Object.assign(JSON.parse(JSON.stringify(basicConfig)), {
+                    config: {
+                        reuseWorkspaceId: workspace.id
+                    }
+                }));
+            }).then(() => {
+                return gtf.wait(3000, () => { done(); unSubFunc(); });
+            }).catch(done);
+        });
+
+        it('not trigger workspace closed', (done) => {
+            let unSubFunc;
+            let workspace;
+
+            glue.workspaces.createWorkspace(basicConfig).then((w) => {
+                workspace = w;
+                return glue.workspaces.onWorkspaceClosed(() => {
+                    try {
+                        done("Should not be invoked");
+
+                        unSubFunc();
+                    } catch (error) { }
+                });
+            }).then((unSub) => {
+                unSubFunc = unSub;
+                return glue.workspaces.createWorkspace(Object.assign(JSON.parse(JSON.stringify(basicConfig)), {
+                    config: {
+                        reuseWorkspaceId: workspace.id
+                    }
+                }));
+            }).then(() => {
+                return gtf.wait(3000, () => { done(); unSubFunc(); });
+            }).catch(done);
+        });
+
+        it("resolve with correct title when it is specified and valid", async () => {
+            const testTitle = "myTestTitle";
+            const workspace = await glue.workspaces.createWorkspace(basicConfig);
+            const secondWorkspace = await glue.workspaces.createWorkspace(
+                Object.assign(JSON.parse(JSON.stringify(secondBasicConfig)), { config: { title: testTitle, reuseWorkspaceId: workspace.id } })
+            );
+
+            expect(secondWorkspace.title).to.eql(testTitle);
+        });
+
+        it("resolve when there are multiple frames opened and one of the middle ones (by starting order) contains the target workspace", async () => {
+            const workspaceOne = await glue.workspaces.createWorkspace(Object.assign(JSON.parse(JSON.stringify(basicConfig)), { frame: { newFrame: true } }));
+            const workspaceTwo = await glue.workspaces.createWorkspace(Object.assign(JSON.parse(JSON.stringify(basicConfig)), { frame: { newFrame: true } }));
+            const workspaceThree = await glue.workspaces.createWorkspace(Object.assign(JSON.parse(JSON.stringify(basicConfig)), { frame: { newFrame: true } }));
+            const workspaceFour = await glue.workspaces.createWorkspace(Object.assign(JSON.parse(JSON.stringify(secondBasicConfig)), { config: { reuseWorkspaceId: workspaceTwo.id } }));
+
+            const allWorkspaces = await glue.workspaces.getAllWorkspaces();
+            const allFrames = await glue.workspaces.getAllFrames();
+            const windowsInWorkspaceFour = workspaceFour.getAllWindows();
+
+            expect(allWorkspaces.length).to.eql(3);
+            expect(allFrames.length).to.eql(3);
+            expect(windowsInWorkspaceFour.length).to.eql(2);
+        });
+
+        it.skip("reject when reuseFrameId is specified", (done) => {
+            glue.workspaces.createWorkspace(basicConfig).then((workspace) => {
+                const reuseFrameConfig = Object.assign(JSON.parse(JSON.stringify(basicConfig)), {
+                    frame: {
+                        newFrame: false,
+                        reuseFrameId: workspace.frame.id
+                    },
+                    config: {
+                        reuseWorkspaceId: workspace.id
+                    }
+                });
+
+                glue.workspaces.createWorkspace(reuseFrameConfig)
+                    .then(() => done("Should not resolve"))
+                    .catch(() => done());
+            }).catch(done);
+
+        });
     });
     // SAVE CONFIG
     // after resolve the layout should be present in the layouts collection when specified in the save config

--- a/e2e/tests/workspaces/API/createWorkspace.spec.js
+++ b/e2e/tests/workspaces/API/createWorkspace.spec.js
@@ -524,23 +524,6 @@ describe('createWorkspace() ', function () {
             expect(secondWorkspaceContext).to.eql(secondContext);
         });
 
-        it('reject and not open a workspace when called with no data', (done) => {
-            glue.workspaces.createWorkspace()
-                .then(() => {
-                    done('Should not have resolved, because the method is called with no arguments');
-                })
-                .catch(() => {
-                    return glue.workspaces.getAllWorkspacesSummaries();
-                })
-                .then((summaries) => {
-                    expect(summaries.length).to.eql(0);
-                    done();
-                })
-                .catch((err) => {
-                    done(err);
-                });
-        });
-
         it('not trigger workspace opened', (done) => {
             let unSubFunc;
             let workspace;

--- a/e2e/tests/workspaces/API/restoreWorkspace.spec.js
+++ b/e2e/tests/workspaces/API/restoreWorkspace.spec.js
@@ -1,4 +1,4 @@
-describe.only('restoreWorkspace() Should', function () {
+describe.skip('restoreWorkspace() Should', function () {
 
     const basicConfig = {
         children: [
@@ -38,21 +38,9 @@ describe.only('restoreWorkspace() Should', function () {
     before(() => coreReady);
 
     beforeEach(async () => {
-        console.log("START");
-        const frames = await glue.workspaces.getAllFrames();
-        const workspaces = await glue.workspaces.getAllWorkspaces();
-        console.log(frames.length);
-        console.log(workspaces.length);
         workspace = await glue.workspaces.createWorkspace(basicConfig);
-        console.log("FIRST CREATED");
-        // await workspace.saveLayout(layoutName);
-        console.log("FIRST");
         let secondWorkspace = await glue.workspaces.createWorkspace(secondBasicConfig);
-        // await secondWorkspace.saveLayout(secondLayoutName, { saveContext: false });
-        // console.log("SECOND");
         await secondWorkspace.close();
-        await gtf.wait(500);
-        // console.log("SECOND CLOSE");
     });
 
     afterEach(async () => {
@@ -60,16 +48,13 @@ describe.only('restoreWorkspace() Should', function () {
         const frames = await glue.workspaces.getAllFrames();
         await Promise.all(frames.map((f) => f.close()));
     });
-    Array.from({ length: 50 }).forEach(() => {
 
-        it("restore the layout when the arguments are correct and the workspace is still opened", async () => {
-            // const secondWorkspace = await glue.workspaces.restoreWorkspace(layoutName);
-            const summaries = await glue.workspaces.getAllWorkspacesSummaries();
+    it("restore the layout when the arguments are correct and the workspace is still opened", async () => {
+        const secondWorkspace = await glue.workspaces.restoreWorkspace(layoutName);
+        const summaries = await glue.workspaces.getAllWorkspacesSummaries();
 
-            // expect(summaries.length).to.eql(2);
-        });
+        expect(summaries.length).to.eql(2);
     });
-
 
     it("restore the layout when the arguments are correct and the workspace is closed", async () => {
         await workspace.close();

--- a/e2e/tests/workspaces/API/restoreWorkspace.spec.js
+++ b/e2e/tests/workspaces/API/restoreWorkspace.spec.js
@@ -1,4 +1,4 @@
-describe.skip('restoreWorkspace() Should', function () {
+describe('restoreWorkspace() Should', function () {
 
     const basicConfig = {
         children: [
@@ -39,7 +39,9 @@ describe.skip('restoreWorkspace() Should', function () {
 
     beforeEach(async () => {
         workspace = await glue.workspaces.createWorkspace(basicConfig);
+        await workspace.saveLayout(layoutName);
         let secondWorkspace = await glue.workspaces.createWorkspace(secondBasicConfig);
+        await secondWorkspace.saveLayout(secondLayoutName);
         await secondWorkspace.close();
     });
 

--- a/e2e/tests/workspaces/API/restoreWorkspace.spec.js
+++ b/e2e/tests/workspaces/API/restoreWorkspace.spec.js
@@ -7,7 +7,7 @@ describe.skip('restoreWorkspace() Should', function () {
                 children: [
                     {
                         type: "window",
-                        appName: "dummyApp"
+                        appName: "noGlueApp"
                     }
                 ]
             }
@@ -21,11 +21,11 @@ describe.skip('restoreWorkspace() Should', function () {
                 children: [
                     {
                         type: "window",
-                        appName: "dummyApp"
+                        appName: "noGlueApp"
                     },
                     {
                         type: "window",
-                        appName: "dummyApp"
+                        appName: "noGlueApp"
                     }
                 ]
             }

--- a/e2e/tests/workspaces/Frame/onWindowLoaded.spec.js
+++ b/e2e/tests/workspaces/Frame/onWindowLoaded.spec.js
@@ -45,7 +45,7 @@ describe('frame.onWindowLoaded ', () => {
                 defaultWorkspace = wsp;
                 defaultFrame = wsp.frame;
                 ready();
-            });
+            }).catch(done);
     });
 
     afterEach(async () => {

--- a/e2e/tests/workspaces/Workspace/saveLayout.spec.js
+++ b/e2e/tests/workspaces/Workspace/saveLayout.spec.js
@@ -86,7 +86,7 @@ describe('saveLayout() Should ', function () {
         const layouts = await glue.workspaces.layouts.export();
         const layoutUnderTest = layouts.find(l => l.name === layoutName);
 
-        expect(layoutUnderTest.components[0].state.context).to.be.a("object").that.is.empty;
+        expect(layoutUnderTest.components[0].state.context).to.not.exist;
     });
 
     it("save the layout without context when the options object is undefined", async () => {
@@ -99,7 +99,7 @@ describe('saveLayout() Should ', function () {
         const layouts = await glue.workspaces.layouts.export();
         const layoutUnderTest = layouts.find(l => l.name === layoutName);
 
-        expect(layoutUnderTest.components[0].state.context).to.be.a("object").that.is.empty;
+        expect(layoutUnderTest.components[0].state.context).to.not.exist;
     });
 
     Array.from([[], {}, 42, undefined, null]).forEach((input) => {

--- a/packages/golden-layout/index.d.ts
+++ b/packages/golden-layout/index.d.ts
@@ -480,6 +480,11 @@ declare module '@glue42/golden-layout' {
              * Hides the tab element of the workspace
              */
             noTabHeader?: boolean;
+
+            /**
+             * Replaces the specified workspace instead of creating a new one
+             */
+            reuseWorkspaceId?: string;
         }
 
         export interface Config {

--- a/packages/web-platform/src/libs/workspaces/controller.ts
+++ b/packages/web-platform/src/libs/workspaces/controller.ts
@@ -198,7 +198,8 @@ export class WorkspacesController implements LibController {
 
         const frameInstanceConfig = {
             frameId: config.frame?.reuseFrameId,
-            newFrame: config.frame?.newFrame
+            newFrame: config.frame?.newFrame,
+            itemId: config.config?.reuseWorkspaceId
         };
 
         const frame = await this.framesController.getFrameInstance(frameInstanceConfig);
@@ -296,7 +297,13 @@ export class WorkspacesController implements LibController {
     private async openWorkspace(config: OpenWorkspaceConfig, commandId: string): Promise<WorkspaceSnapshotResult> {
         this.logger?.trace(`[${commandId}] handling openWorkspace command for name: ${config.name}`);
 
-        const frame = await this.framesController.getFrameInstance({ frameId: config.restoreOptions?.frameId, newFrame: config.restoreOptions?.newFrame });
+        const frameQueryConfig = {
+            frameId: config.restoreOptions?.frameId,
+            newFrame: config.restoreOptions?.newFrame,
+            itemId: config.restoreOptions?.reuseWorkspaceId
+        };
+        
+        const frame = await this.framesController.getFrameInstance(frameQueryConfig);
 
         const result = await this.glueController.callFrame<OpenWorkspaceConfig, WorkspaceSnapshotResult>(this.operations.openWorkspace, config, frame.windowId);
 

--- a/packages/web-platform/src/libs/workspaces/controller.ts
+++ b/packages/web-platform/src/libs/workspaces/controller.ts
@@ -5,7 +5,7 @@ import { Glue42Workspaces } from "@glue42/workspaces-api";
 import { BridgeOperation, CoreClientData, InternalPlatformConfig, LibController } from "../../common/types";
 import { addContainerConfigDecoder, addItemResultDecoder, addWindowConfigDecoder, bundleConfigDecoder, deleteLayoutConfigDecoder, exportedLayoutsResultDecoder, frameHelloDecoder, frameSnapshotResultDecoder, frameStateConfigDecoder, frameStateResultDecoder, frameSummariesResultDecoder, frameSummaryDecoder, getFrameSummaryConfigDecoder, isWindowInSwimlaneResultDecoder, layoutSummariesDecoder, moveFrameConfigDecoder, moveWindowConfigDecoder, openWorkspaceConfigDecoder, resizeItemConfigDecoder, setItemTitleConfigDecoder, simpleItemConfigDecoder, simpleWindowOperationSuccessResultDecoder, voidResultDecoder, workspaceCreateConfigDecoder, workspaceLayoutDecoder, workspaceLayoutSaveConfigDecoder, workspacesLayoutImportConfigDecoder, workspaceSnapshotResultDecoder, workspacesOperationDecoder, workspaceSummariesResultDecoder } from "./decoders";
 import { FramesController } from "./frames";
-import { AddContainerConfig, AddItemResult, AddWindowConfig, BundleConfig, DeleteLayoutConfig, ExportedLayoutsResult, FrameHello, FrameSnapshotResult, FrameStateConfig, FrameStateResult, FrameSummariesResult, FrameSummaryResult, GetFrameSummaryConfig, IsWindowInSwimlaneResult, LayoutSummariesResult, LayoutSummary, MoveFrameConfig, MoveWindowConfig, OpenWorkspaceConfig, ResizeItemConfig, SetItemTitleConfig, SimpleItemConfig, SimpleWindowOperationSuccessResult, WorkspaceCreateConfigProtocol, WorkspacesLayoutImportConfig, WorkspaceSnapshotResult, WorkspacesOperationsTypes, WorkspaceSummariesResult, WorkspaceSummaryResult } from "./types";
+import { AddContainerConfig, AddItemResult, AddWindowConfig, BundleConfig, DeleteLayoutConfig, ExportedLayoutsResult, FrameHello, FrameSnapshotResult, FrameStateConfig, FrameStateResult, FrameSummariesResult, FrameSummaryResult, GetFrameSummaryConfig, IsWindowInSwimlaneResult, LayoutSummariesResult, LayoutSummary, MoveFrameConfig, MoveWindowConfig, OpenWorkspaceConfig, ResizeItemConfig, SetItemTitleConfig, SimpleItemConfig, SimpleWindowOperationSuccessResult, WorkspaceConfigWithReuseWorkspaceId, WorkspaceCreateConfigProtocol, WorkspacesLayoutImportConfig, WorkspaceSnapshotResult, WorkspacesOperationsTypes, WorkspaceSummariesResult, WorkspaceSummaryResult } from "./types";
 import logger from "../../shared/logger";
 import { Glue42WebPlatform } from "../../../platform";
 import { GlueController } from "../../controllers/glue";
@@ -199,7 +199,7 @@ export class WorkspacesController implements LibController {
         const frameInstanceConfig = {
             frameId: config.frame?.reuseFrameId,
             newFrame: config.frame?.newFrame,
-            itemId: config.config?.reuseWorkspaceId
+            itemId: (config.config as WorkspaceConfigWithReuseWorkspaceId)?.reuseWorkspaceId
         };
 
         const frame = await this.framesController.getFrameInstance(frameInstanceConfig);
@@ -300,9 +300,9 @@ export class WorkspacesController implements LibController {
         const frameQueryConfig = {
             frameId: config.restoreOptions?.frameId,
             newFrame: config.restoreOptions?.newFrame,
-            itemId: config.restoreOptions?.reuseWorkspaceId
+            itemId: (config.restoreOptions as WorkspaceConfigWithReuseWorkspaceId)?.reuseWorkspaceId
         };
-        
+
         const frame = await this.framesController.getFrameInstance(frameQueryConfig);
 
         const result = await this.glueController.callFrame<OpenWorkspaceConfig, WorkspaceSnapshotResult>(this.operations.openWorkspace, config, frame.windowId);

--- a/packages/web-platform/src/libs/workspaces/types.ts
+++ b/packages/web-platform/src/libs/workspaces/types.ts
@@ -267,3 +267,5 @@ export interface WindowStreamData {
         config: SwimlaneWindowSnapshotConfig;
     };
 }
+
+export type WorkspaceConfigWithReuseWorkspaceId = Glue42Workspaces.WorkspaceConfig & { reuseWorkspaceId: string };

--- a/packages/workspaces-api/src/shared/decoders.ts
+++ b/packages/workspaces-api/src/shared/decoders.ts
@@ -142,7 +142,8 @@ export const workspaceDefinitionDecoder: Decoder<Glue42Workspaces.WorkspaceDefin
         title: optional(nonEmptyStringDecoder),
         position: optional(nonNegativeNumberDecoder),
         isFocused: optional(boolean()),
-        noTabHeader: optional(boolean())
+        noTabHeader: optional(boolean()),
+        reuseWorkspaceId: optional(nonEmptyStringDecoder)
     })),
     frame: optional(object({
         reuseFrameId: optional(nonEmptyStringDecoder),

--- a/packages/workspaces-api/workspaces.d.ts
+++ b/packages/workspaces-api/workspaces.d.ts
@@ -113,6 +113,9 @@ export namespace Glue42Workspaces {
 
         /** A setting used to declare that the workspace must be in a new frame and also provide options for that new frame */
         newFrame?: NewFrameConfig | boolean;
+
+        /** Used for replacing the specified workspace instead of creating a new one */
+        reuseWorkspaceId?: string;
     }
 
     /** An object describing the possible settings when defining a new frame. */
@@ -185,6 +188,9 @@ export namespace Glue42Workspaces {
 
         /** Provides the opportunity to open a workspace with no tab header */
         noTabHeader?: boolean;
+
+        /** Used for replacing the specified workspace instead of creating a new one */
+        reuseWorkspaceId?: string;
     }
 
     /** An object describing the possible options when defining a new workspace */

--- a/packages/workspaces-api/workspaces.d.ts
+++ b/packages/workspaces-api/workspaces.d.ts
@@ -113,9 +113,6 @@ export namespace Glue42Workspaces {
 
         /** A setting used to declare that the workspace must be in a new frame and also provide options for that new frame */
         newFrame?: NewFrameConfig | boolean;
-
-        /** Used for replacing the specified workspace instead of creating a new one */
-        reuseWorkspaceId?: string;
     }
 
     /** An object describing the possible settings when defining a new frame. */
@@ -188,9 +185,6 @@ export namespace Glue42Workspaces {
 
         /** Provides the opportunity to open a workspace with no tab header */
         noTabHeader?: boolean;
-
-        /** Used for replacing the specified workspace instead of creating a new one */
-        reuseWorkspaceId?: string;
     }
 
     /** An object describing the possible options when defining a new workspace */

--- a/packages/workspaces-ui-core/src/interop/facade.ts
+++ b/packages/workspaces-ui-core/src/interop/facade.ts
@@ -345,7 +345,13 @@ export class GlueFacade {
     }
 
     private async handleCreateWorkspace(operationArguments: CreateWorkspaceArguments) {
+        if (!operationArguments.config) {
+            operationArguments.config = {};
+        }
+        
+        operationArguments.config.context = operationArguments.config.context || operationArguments.context;
         const config = this._converter.convertToRendererConfig(operationArguments);
+
         const workspaceId = await manager.createWorkspace(config as GoldenLayout.Config);
 
         const apiConfig = this._converter.convertToAPIConfig(manager.stateResolver.getWorkspaceConfig(workspaceId));

--- a/packages/workspaces-ui-core/src/interop/types.ts
+++ b/packages/workspaces-ui-core/src/interop/types.ts
@@ -168,6 +168,7 @@ export interface RestoreWorkspaceConfig {
     title?: string;
     context?: object;
     noTabHeader?: boolean;
+    reuseWorkspaceId?: string;
 }
 
 export interface AddWindowArguments {
@@ -189,7 +190,8 @@ export interface AddWorkspaceChildrenArguments {
 
 export interface CreateWorkspaceArguments extends WorkspaceItem {
     // add the save config
-    saveConfig: object;
+    saveConfig?: object;
+    context?: object;
 }
 
 export interface MoveFrameArguments {

--- a/packages/workspaces-ui-core/src/layout/controller.ts
+++ b/packages/workspaces-ui-core/src/layout/controller.ts
@@ -261,6 +261,15 @@ export class LayoutController {
         this.emitter.raiseEvent("workspace-added", { workspace: store.getById(id) });
     }
 
+    public reinitializeWorkspace(id: string, config: GoldenLayout.Config) {
+        store.removeLayout(id);
+        if (config.workspacesOptions?.reuseWorkspaceId) {
+            // Making sure that the property doesn't leak in a workspace summary or a saved layout
+            delete config.workspacesOptions.reuseWorkspaceId;
+        }
+        return this.initWorkspaceContents(id, config);
+    }
+
     public removeWorkspace(workspaceId: string) {
         const workspaceToBeRemoved = store.getWorkspaceLayoutItemById(workspaceId);
 
@@ -654,7 +663,7 @@ export class LayoutController {
     }
 
     private initWorkspaceConfig(workspaceConfig: GoldenLayout.Config) {
-        return new Promise((res) => {
+        return new Promise<void>((res) => {
             workspaceConfig.settings.selectionEnabled = true;
             store.workspaceLayout = new GoldenLayout(workspaceConfig, $(this._workspaceLayoutElementId), componentStateMonitor.decoratedFactory);
 
@@ -905,7 +914,7 @@ export class LayoutController {
     }
 
     private waitForLayout(id: string) {
-        return new Promise((res) => {
+        return new Promise<void>((res) => {
             const unsub = this._registry.add(`content-layout-initialised-${id}`, () => {
                 res();
                 unsub();
@@ -919,7 +928,7 @@ export class LayoutController {
     }
 
     private waitForWindowContainer(placementId: string) {
-        return new Promise((res) => {
+        return new Promise<void>((res) => {
             const unsub = this.emitter.onContentComponentCreated((component) => {
                 if (component.config.id === placementId) {
                     res();

--- a/packages/workspaces-ui-core/src/layouts.ts
+++ b/packages/workspaces-ui-core/src/layouts.ts
@@ -126,11 +126,11 @@ export class LayoutsManager {
         if (title) {
             workspaceConfig.config.title = title;
         }
-        let workspaceContext = {};
+        let workspaceContext = undefined;
 
         if (saveContext) {
             try {
-                workspaceContext = await this.getWorkspaceContext(workspace.id) || {}
+                workspaceContext = await this.getWorkspaceContext(workspace.id);
             } catch (error) {
                 // can throw an exception when reloading
             }

--- a/packages/workspaces-ui-core/src/manager.ts
+++ b/packages/workspaces-ui-core/src/manager.ts
@@ -155,9 +155,21 @@ class WorkspacesManager {
 
             return idAsString(savedConfig.id);
         } else if (name) {
-            savedConfig.id = this._configFactory.getId();
+            savedConfig.id = options?.reuseWorkspaceId || this._configFactory.getId();
 
-            await this.addWorkspace(idAsString(savedConfig.id), savedConfig);
+            if (options?.reuseWorkspaceId) {
+                const workspace = store.getById(savedConfig.id);
+
+                workspace.windows.map((w) => store.getWindowContentItem(w.id))
+                    .filter((w) => w)
+                    .map((w) => this.closeTab(w, false));
+                await this._controller.reinitializeWorkspace(savedConfig.id, savedConfig);
+                if (savedConfig.workspacesOptions?.context) {
+                    await this._glue.contexts.set(getWorkspaceContextName(savedConfig.id), savedConfig.workspacesOptions.context);
+                }
+            } else {
+                await this.addWorkspace(idAsString(savedConfig.id), savedConfig);
+            }
 
             return idAsString(savedConfig.id);
         }
@@ -240,9 +252,21 @@ class WorkspacesManager {
             return idAsString(config.id);
         }
 
-        const id = this._configFactory.getId();
+        const id = config.workspacesOptions?.reuseWorkspaceId || this._configFactory.getId();
 
-        await this.addWorkspace(id, config);
+        if (config.workspacesOptions?.reuseWorkspaceId) {
+            const workspace = store.getById(id);
+
+            workspace.windows.map((w) => store.getWindowContentItem(w.id))
+                .filter((w) => w)
+                .map((w) => this.closeTab(w, false));
+            await this._controller.reinitializeWorkspace(id, config);
+            if (config.workspacesOptions.context) {
+                await this._glue.contexts.set(getWorkspaceContextName(id), config.workspacesOptions.context);
+            }
+        } else {
+            await this.addWorkspace(id, config);
+        }
 
         return id;
     }
@@ -351,6 +375,7 @@ class WorkspacesManager {
         this.subscribeForLayout();
 
         this._isLayoutInitialized = true;
+        console.log("WAITING ENDED");
 
         await Promise.all(config.workspaceConfigs.map(c => {
             return this._glue.contexts.set(getWorkspaceContextName(c.id), c.config?.workspacesOptions?.context || {});

--- a/packages/workspaces-ui-core/src/manager.ts
+++ b/packages/workspaces-ui-core/src/manager.ts
@@ -375,7 +375,6 @@ class WorkspacesManager {
         this.subscribeForLayout();
 
         this._isLayoutInitialized = true;
-        console.log("WAITING ENDED");
 
         await Promise.all(config.workspaceConfigs.map(c => {
             return this._glue.contexts.set(getWorkspaceContextName(c.id), c.config?.workspacesOptions?.context || {});

--- a/packages/workspaces-ui-core/src/store.ts
+++ b/packages/workspaces-ui-core/src/store.ts
@@ -53,7 +53,7 @@ class WorkspaceStore {
     }
 
     public removeLayout(id: string) {
-        this._idToLayout[id].layout.destroy();
+        this._idToLayout[id].layout?.destroy();
         this._idToLayout[id].layout = undefined;
     }
 

--- a/packages/workspaces-ui-core/src/types/internal.ts
+++ b/packages/workspaces-ui-core/src/types/internal.ts
@@ -13,6 +13,7 @@ export interface WorkspaceItem {
     config?: {
         name?: string;
         context?: object;
+        reuseWorkspaceId?: string;
         [k: string]: object | string;
     };
 }


### PR DESCRIPTION
Added the option to pass a `reuseWorkspaceId` parameter that changes the targeted workspace contents without closing  and reopening the workspace through `createWorkspace` and `restoreWorkspace`