### PR TITLE
Added requestFocus() in workspaces-ui-react

### DIFF
--- a/packages/golden-layout/src/js/controls/Tab.js
+++ b/packages/golden-layout/src/js/controls/Tab.js
@@ -133,7 +133,7 @@ lm.utils.copy(lm.controls.Tab.prototype, {
 		}
 		const isWorkspaceLayout = this.contentItem.layoutManager.config.settings.mode === "workspace";
 		const hasLessThanTwoTabs = this.contentItem.parent.header.tabs.length < 2;
-		const isMissingWindowId = !this.contentItem.config.windowId && !this.contentItem.config.componentState.windowId;
+		const isMissingWindowId = !this.contentItem.config.windowId && (this.contentItem.config.componentState && !this.contentItem.config.componentState.windowId);
 
 		if (isWorkspaceLayout && hasLessThanTwoTabs) {
 			return;

--- a/packages/workspaces-ui-core/src/export.ts
+++ b/packages/workspaces-ui-core/src/export.ts
@@ -71,6 +71,9 @@ const workspacesManagerAPI: WorkspacesManager = {
     },
     notifyWorkspacePopupChanged: (element: HTMLElement) => {
         return;
+    },
+    requestFocus: () => {
+        return;
     }
 }
 

--- a/packages/workspaces-ui-core/src/iframeController.ts
+++ b/packages/workspaces-ui-core/src/iframeController.ts
@@ -159,7 +159,7 @@ export class IFrameController {
     }
 
     private waitForWindow(windowId: string) {
-        return new Promise((res, rej) => {
+        return new Promise<void>((res, rej) => {
             let unsub = () => {
                 // safety
             };

--- a/packages/workspaces-ui-core/src/manager.ts
+++ b/packages/workspaces-ui-core/src/manager.ts
@@ -888,7 +888,7 @@ class WorkspacesManager {
     }
 
     private waitForFrameLoaded(itemId: string) {
-        return new Promise((res, rej) => {
+        return new Promise<void>((res, rej) => {
             let unsub = () => {
                 // safety
             };

--- a/packages/workspaces-ui-core/workspaces.d.ts
+++ b/packages/workspaces-ui-core/workspaces.d.ts
@@ -1,4 +1,4 @@
-import { Bounds, ComponentFactory } from "./src/types/internal";
+import { Bounds } from "./src/types/internal";
 import { Glue42Web } from "@glue42/web";
 
 export interface WorkspacesManager {
@@ -12,6 +12,7 @@ export interface WorkspacesManager {
     unmount: () => void;
     subscribeForWindowFocused: (callback: () => void) => void;
     notifyWorkspacePopupChanged: (element: HTMLElement) => void;
+    requestFocus: () => void;
 }
 
 declare const WorkspacesManagerAPI: WorkspacesManager;

--- a/packages/workspaces-ui-react/src/index.tsx
+++ b/packages/workspaces-ui-react/src/index.tsx
@@ -46,6 +46,7 @@ export {
 export const notifyMoveAreaChanged: () => void = () => workspacesManager?.notifyMoveAreaChanged();
 export const getComponentBounds: () => Bounds = () => workspacesManager?.getComponentBounds();
 export const getFrameId: () => string = () => workspacesManager?.getFrameId();
+export const requestFocus: () => void = () => workspacesManager?.requestFocus();
 
 export {
     WorkspacesProps,

--- a/packages/workspaces-ui-react/src/types/internal.ts
+++ b/packages/workspaces-ui-react/src/types/internal.ts
@@ -60,6 +60,7 @@ export interface WorkspacesManager {
   removePopupById(elementId: string): void;
   subscribeForWindowFocused(cb: () => any): () => void;
   unmount(): void;
+  requestFocus(): void;
 }
 
 export interface HeaderComponentProps {

--- a/packages/workspaces-ui-react/src/workspacesManager.ts
+++ b/packages/workspaces-ui-react/src/workspacesManager.ts
@@ -13,7 +13,7 @@ class WorkspacesManagerDecorator {
     }
 
     public getFrameId() {
-      return  (window.workspacesManager || workspacesManager).getFrameId();
+        return (window.workspacesManager || workspacesManager).getFrameId();
     }
 
     public notifyMoveAreaChanged() {
@@ -46,6 +46,10 @@ class WorkspacesManagerDecorator {
 
     public unmount(): void {
         return (window.workspacesManager || workspacesManager).unmount();
+    }
+
+    public requestFocus(): void {
+        return (window.workspacesManager || workspacesManager).requestFocus();
     }
 }
 


### PR DESCRIPTION
Added `requestFocus()` which should be used when the frame is running in Glue42Desktop and custom elements that require focus are stopping the propagation of `mousedown` and `pointerdown`.