### PR TITLE
Nest the intent metadata inside a intent property of the method flags

### DIFF
--- a/packages/fdc3/src/channels/channels.ts
+++ b/packages/fdc3/src/channels/channels.ts
@@ -18,7 +18,7 @@ interface PendingSubscription {
 }
 
 const createChannelsAgent = (): ChannelsAPI => {
-    let currentChannel: Channel | null;
+    let currentChannel: Channel | null = null;
     let pendingSubscription: PendingSubscription | null;
 
     const channels: { [name: string]: Channel } = {};

--- a/packages/web-platform/src/libs/intents/controller.ts
+++ b/packages/web-platform/src/libs/intents/controller.ts
@@ -112,7 +112,7 @@ export class IntentsController implements LibController {
                     intents[intentName] = [];
                 }
 
-                const info = method.flags as Glue42Web.Intents.AddIntentListenerRequest;
+                const info = method.flags.intent as Omit<Glue42Web.Intents.AddIntentListenerRequest, "intent">;
 
                 const app = apps.find((appDef) => appDef.name === server.application);
                 let appIntent: IntentInfo | undefined;

--- a/packages/web/src/intents/controller.ts
+++ b/packages/web/src/intents/controller.ts
@@ -114,9 +114,16 @@ export class IntentsController implements LibController {
                 }
             }
         };
-        const flags = typeof intent === "string" ? { intent } : intent;
 
-        this.interop.register({ name: methodName, flags }, (args: Glue42Web.Intents.IntentContext) => {
+        let intentFlag: Omit<Glue42Web.Intents.AddIntentListenerRequest, "intent"> = {};
+
+        if (typeof intent === "object") {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const { intent: removed, ...rest } = intent;
+            intentFlag = rest;
+        }
+
+        this.interop.register({ name: methodName, flags: { intent: intentFlag } }, (args: Glue42Web.Intents.IntentContext) => {
             if (subscribed) {
                 return handler(args);
             }


### PR DESCRIPTION
Omit the intent name from the intent metadata
Return null inside of `getCurrentChannel()` when the app is not joined to a channel