### PR TITLE
Implement hibernate resume workspace

### DIFF
--- a/e2e/tests/workspaces/API/onWindowRemoved.spec.js
+++ b/e2e/tests/workspaces/API/onWindowRemoved.spec.js
@@ -1,7 +1,7 @@
 describe('onWindowRemoved ', () => {
     const windowConfig = {
         type: "window",
-        appName: "dummyApp"
+        appName: "noGlueApp"
     };
 
     const basicConfig = {
@@ -112,6 +112,76 @@ describe('onWindowRemoved ', () => {
                 })
                 .then(ready)
                 .catch(done);
+        });
+
+        Array.from({ length: 5 }).forEach((_, i) => {
+            it(`invoke the callback ${i + 1} time/s when the workspace is closed`, (done) => {
+                const ready = gtf.waitFor(i + 1, () => done());
+
+                glue.workspaces.onWindowRemoved((window) => {
+                    ready();
+                }).then((unsub) => {
+                    gtf.addWindowHook(unsub);
+
+                    return Promise.all(Array.from({ length: i }).map(() => defaultWorkspace.addWindow(windowConfig)));
+                }).then(() => {
+                    return defaultWorkspace.frame.createWorkspace(basicConfig);
+                }).then(() => {
+                    return defaultWorkspace.close();
+                }).catch(done);
+            });
+
+            it(`invoke the callback ${i + 1} time/s when the workspace is closed and is hibernated`, (done) => {
+                const ready = gtf.waitFor(i + 1, () => done());
+
+                glue.workspaces.onWindowRemoved((window) => {
+                    ready();
+                }).then((unsub) => {
+                    gtf.addWindowHook(unsub);
+
+                    return Promise.all(Array.from({ length: i }).map(() => defaultWorkspace.addWindow(windowConfig)));
+                }).then(() => {
+                    return defaultWorkspace.frame.createWorkspace(basicConfig);
+                }).then(() => {
+                    return defaultWorkspace.hibernate();
+                }).then(() => {
+                    return defaultWorkspace.close();
+                }).catch(done);
+            });
+
+            it(`invoke the callback ${i + 1} time/s when the frame is closed`, (done) => {
+                const ready = gtf.waitFor(i + 1, () => done());
+
+                glue.workspaces.onWindowRemoved((window) => {
+                    ready();
+                }).then((unsub) => {
+                    gtf.addWindowHook(unsub);
+
+                    return Promise.all(Array.from({ length: i }).map(() => defaultWorkspace.addWindow(windowConfig)));
+                }).then(() => {
+                    return defaultWorkspace.frame.createWorkspace(basicConfig);
+                }).then(() => {
+                    return defaultWorkspace.frame.close();
+                }).catch(done);
+            });
+
+            it(`invoke the callback ${i + 1} time/s when the frame is closed and the workspace is hibernated`, (done) => {
+                const ready = gtf.waitFor(i + 2, () => done());
+
+                glue.workspaces.onWindowRemoved((window) => {
+                    ready();
+                }).then((unsub) => {
+                    gtf.addWindowHook(unsub);
+
+                    return Promise.all(Array.from({ length: i }).map(() => defaultWorkspace.addWindow(windowConfig)));
+                }).then(() => {
+                    return defaultWorkspace.frame.createWorkspace(basicConfig);
+                }).then(() => {
+                    return defaultWorkspace.hibernate();
+                }).then(() => {
+                    return defaultWorkspace.frame.close();
+                }).catch(done);
+            });
         });
 
         it('should not notify when immediately unsubscribed', (done) => {

--- a/e2e/tests/workspaces/Workspace/close.spec.js
+++ b/e2e/tests/workspaces/Workspace/close.spec.js
@@ -72,6 +72,26 @@ describe('close() Should ', function () {
         expect(isWorkspaceInCollection).to.be.false;
     });
 
+    it("successfully close the workspace when its hibernated", async () => {
+        await workspace.frame.createWorkspace(basicConfig);
+        await workspace.hibernate();
+        await workspace.close();
+    });
+
+    it("remove the workspace from the summary list when its hibernated and then close", async () => {
+        await workspace.frame.createWorkspace(basicConfig);
+        await workspace.hibernate();
+        const allWorkspacesCount = (await glue.workspaces.getAllWorkspacesSummaries()).length;
+        await workspace.close();
+
+        const getAllWorkspaces = await glue.workspaces.getAllWorkspacesSummaries();
+
+        const isWorkspaceInCollection = getAllWorkspaces.filter(w => w.id === workspace.id).length > 0;
+
+        expect(isWorkspaceInCollection).to.be.false;
+        expect(allWorkspacesCount - 1).to.eql(getAllWorkspaces.length);
+    });
+
     it("remove the workspace from getAllWorkspacesSummaries when the workspace has been closed twice", async () => {
         try {
             await Promise.all([workspace.close(), workspace.close()]);

--- a/e2e/tests/workspaces/Workspace/hibernate.spec.js
+++ b/e2e/tests/workspaces/Workspace/hibernate.spec.js
@@ -1,0 +1,272 @@
+describe("hibernate() Should", () => {
+    const basicConfig = {
+        children: [{
+            type: "column",
+            children: [{
+                type: "row",
+                children: [
+                    {
+                        type: "group",
+                        children: [
+                            {
+                                type: "window",
+                                appName: "noGlueApp"
+                            }
+                        ]
+                    },
+                    {
+                        type: "group",
+                        children: [
+                            {
+                                type: "window",
+                                appName: "noGlueApp"
+                            }
+                        ]
+                    },
+                ],
+            },
+            {
+                type: "group",
+                children: [
+                    {
+                        type: "window",
+                        appName: "dummyApp"
+                    }
+                ]
+            }]
+        }]
+    };
+
+    const basicConfigTwoWindows = {
+        children: [{
+            type: "column",
+            children: [{
+                type: "row",
+                children: [
+                    {
+                        type: "group",
+                        children: [
+                            {
+                                type: "window",
+                                appName: "noGlueApp"
+                            }
+                        ]
+                    },
+                    {
+                        type: "group",
+                        children: [
+                            {
+                                type: "window",
+                                appName: "dummyApp"
+                            }
+                        ]
+                    },
+                ],
+            }]
+        }]
+    };
+
+    let workspace = undefined;
+
+    before(async () => {
+        await coreReady;
+    });
+
+    beforeEach(async () => {
+        gtf.clearWindowActiveHooks();
+        workspace = await glue.workspaces.createWorkspace(basicConfig);
+    })
+
+    afterEach(async () => {
+        const wsps = await glue.workspaces.getAllWorkspaces();
+        await Promise.all(wsps.map((wsp) => wsp.close()));
+    });
+
+    it("resolve the promise when the workspace is not selected", async () => {
+        const secondWorkspace = await workspace.frame.createWorkspace(basicConfig);
+
+        return workspace.hibernate();
+    });
+
+    it("close the windows in the hibernated workspace", async () => {
+        await Promise.all(workspace.getAllWindows().map((w) => w.forceLoad()));
+
+        const windowsInHibernatedWorkspace = workspace.getAllWindows().length;
+
+        const secondWorkspace = await workspace.frame.createWorkspace(basicConfig);
+
+        await Promise.all(secondWorkspace.getAllWindows().map((w) => w.forceLoad()));
+
+        const beforeHibernateWindowCount = glue.windows.list().length;
+
+        await workspace.hibernate();
+
+        const afterHibernateWindowCount = glue.windows.list().length;
+
+        expect(beforeHibernateWindowCount).to.eql(afterHibernateWindowCount + windowsInHibernatedWorkspace);
+    });
+
+    it("have workspace windows which are not loaded", async () => {
+        await Promise.all(workspace.getAllWindows().map((w) => w.forceLoad()));
+
+        const secondWorkspace = await workspace.frame.createWorkspace(basicConfig);
+
+        await Promise.all(secondWorkspace.getAllWindows().map((w) => w.forceLoad()));
+        await workspace.hibernate();
+        await workspace.refreshReference();
+
+        workspace.getAllWindows().forEach((w) => {
+            expect(w.isLoaded).to.eql(false);
+            let hasFoundGdWindow = undefined;
+            try {
+                hasFoundGdWindow = !!w.getGdWindow();
+            } catch (error) {
+                hasFoundGdWindow = false;
+            }
+            expect(hasFoundGdWindow).to.be.false;
+        });
+    });
+
+    it("have the same amount of workspace windows as before being hibernated", async () => {
+        await Promise.all(workspace.getAllWindows().map((w) => w.forceLoad()));
+
+        const workspaceWindowsCount = workspace.getAllWindows().length;
+        const secondWorkspace = await workspace.frame.createWorkspace(basicConfig);
+
+        await Promise.all(secondWorkspace.getAllWindows().map((w) => w.forceLoad()));
+        await workspace.hibernate();
+        await workspace.refreshReference();
+
+        const workspaceWindowsCountAfterHibernate = workspace.getAllWindows().length;
+
+        expect(workspaceWindowsCount).to.eql(workspaceWindowsCountAfterHibernate);
+    });
+
+    it("have the same amount of columns as before being hibernated", async () => {
+        const columnsCount = workspace.getAllColumns().length;
+        const secondWorkspace = await workspace.frame.createWorkspace(basicConfig);
+
+        await workspace.hibernate();
+        await workspace.refreshReference();
+
+        const columnsCountAfterHibernate = workspace.getAllColumns().length;
+
+        expect(columnsCount).to.eql(columnsCountAfterHibernate);
+    });
+
+    it("have the same amount of rows as before being hibernated", async () => {
+        const rowsCount = workspace.getAllRows().length;
+        const secondWorkspace = await workspace.frame.createWorkspace(basicConfig);
+
+        await workspace.hibernate();
+        await workspace.refreshReference();
+
+        const rowsCountAfterHibernate = workspace.getAllRows().length;
+
+        expect(rowsCount).to.eql(rowsCountAfterHibernate);
+    });
+
+    it("have the same amount of groups as before being hibernated", async () => {
+        const groupsCount = workspace.getAllGroups().length;
+        const secondWorkspace = await workspace.frame.createWorkspace(basicConfig);
+
+        await workspace.hibernate();
+        await workspace.refreshReference();
+
+        const groupsCountAfterHibernate = workspace.getAllGroups().length;
+
+        expect(groupsCount).to.eql(groupsCountAfterHibernate);
+    });
+
+    it("resume when the workspace is selected after being hibernated", async () => {
+        const secondWorkspace = await workspace.frame.createWorkspace(basicConfig);
+
+        await workspace.hibernate();
+        await workspace.focus();
+        await workspace.refreshReference();
+
+        expect(workspace.isHibernated).to.be.false;
+    });
+
+    it("not trigger onWindowLoaded when the workspace is selected after being hibernated", (done) => {
+        const allWindowsInWorkspace = workspace.getAllWindows();
+
+        Promise.all(allWindowsInWorkspace.map(w => w.forceLoad())).then(() => {
+            return workspace.frame.createWorkspace(basicConfigTwoWindows);
+        }).then(() => {
+            return workspace.onWindowLoaded(() => {
+                gtf.wait(10000).then(() => {
+                    done("Should not resolve");
+                });
+            });
+        }).then((unSub) => {
+            gtf.addWindowHook(unSub);
+            return workspace.hibernate();
+        }).then(() => {
+            gtf.wait(5000, () => {
+                done();
+            });
+            return workspace.focus();
+        }).catch(done)
+    });
+
+    it("not trigger onWindowRemoved after being hibernated", (done) => {
+        workspace.frame.createWorkspace(basicConfig).then(() => {
+            return workspace.onWindowRemoved(() => {
+                done("Should not resolve");
+            })
+        }).then((unsub) => {
+            gtf.addWindowHook(unsub);
+            gtf.wait(3000, () => {
+                done();
+            });
+            return workspace.hibernate();
+        }).catch(done);
+
+    });
+
+    it("throw an error when the workspace is selected", (done) => {
+        workspace.hibernate().then(() => {
+            done("Should not resolve");
+        }).catch(() => {
+            done();
+        });
+    });
+
+    it("throw an error when the workspace is empty", (done) => {
+        let secondWorkspace = undefined;
+        workspace.frame.createWorkspace({ children: [] }).then((w) => {
+            secondWorkspace = w;
+            return workspace.frame.createWorkspace({ children: [] })
+        }).then(() => {
+            return secondWorkspace.hibernate();
+        }).then(() => {
+            done("Should not resolve");
+        }).catch(() => {
+            done();
+        });
+    });
+
+    it("throw an error when the workspace is not selected and hibernated twice (sequential)", (done) => {
+        workspace.frame.createWorkspace(basicConfig).then(() => {
+            return workspace.hibernate();
+        }).then(() => {
+            return workspace.hibernate();
+        }).then(() => {
+            done("Should not resolve");
+        }).catch(() => {
+            done()
+        });
+
+    });
+
+    it("throw an errorwhen the workspace is not selected and hibernated twice (parallel)", (done) => {
+        workspace.frame.createWorkspace(basicConfig).then(() => {
+            return Promise.all([workspace.hibernate(), workspace.hibernate()]);
+        }).then(() => {
+            done("Should not resolve");
+        }).catch(() => {
+            done()
+        });
+    });
+});

--- a/e2e/tests/workspaces/Workspace/properties.spec.js
+++ b/e2e/tests/workspaces/Workspace/properties.spec.js
@@ -374,4 +374,48 @@ describe("properties: ", () => {
             expect(workspace.layoutName).to.eql(undefined);
         });
     });
+
+    describe("isHibernated: Should", () => {
+        let workspace;
+
+        beforeEach(async () => {
+            workspace = await glue.workspaces.createWorkspace(threeContainersConfig);
+        });
+
+        afterEach(async () => {
+            const wsps = await glue.workspaces.getAllWorkspaces();
+            await Promise.all(wsps.map((wsp) => wsp.close()));
+        });
+
+        it("be false when the workspace hasnt been hibernated", () => {
+            expect(workspace.isHibernated).to.be.false;
+        });
+
+        it("be true when the workspace has been hibernated", async () => {
+            await workspace.frame.createWorkspace(threeContainersConfig);
+            await workspace.hibernate();
+            await workspace.refreshReference();
+
+            expect(workspace.isHibernated).to.be.true;
+        });
+
+        it("be false when the workspace has been resumed", async () => {
+            await workspace.frame.createWorkspace(threeContainersConfig);
+            await workspace.hibernate();
+            await workspace.resume();
+            await workspace.refreshReference();
+
+            expect(workspace.isHibernated).to.be.false;
+        });
+
+        it("be true when the workspace has been resumed and then hibernated", async () => {
+            await workspace.frame.createWorkspace(threeContainersConfig);
+            await workspace.hibernate();
+            await workspace.resume();
+            await workspace.hibernate();
+            await workspace.refreshReference();
+
+            expect(workspace.isHibernated).to.be.true;
+        });
+    });
 });

--- a/e2e/tests/workspaces/Workspace/resume.spec.js
+++ b/e2e/tests/workspaces/Workspace/resume.spec.js
@@ -1,0 +1,178 @@
+describe("resume() Should", () => {
+    const basicConfig = {
+        children: [{
+            type: "column",
+            children: [{
+                type: "row",
+                children: [
+                    {
+                        type: "group",
+                        children: [
+                            {
+                                type: "window",
+                                appName: "noGlueApp"
+                            }
+                        ]
+                    },
+                    {
+                        type: "group",
+                        children: [
+                            {
+                                type: "window",
+                                appName: "noGlueApp"
+                            }
+                        ]
+                    },
+                ],
+            },
+            {
+                type: "group",
+                children: [
+                    {
+                        type: "window",
+                        appName: "noGlueApp"
+                    }
+                ]
+            }]
+        }]
+    };
+
+    let workspace = undefined;
+
+    beforeEach(async () => {
+        gtf.clearWindowActiveHooks();
+        workspace = await glue.workspaces.createWorkspace(basicConfig);
+    })
+
+    afterEach(async () => {
+        const wsps = await glue.workspaces.getAllWorkspaces();
+        await Promise.all(wsps.map((wsp) => wsp.close()));
+    });
+
+    it("resolve the promise when the workspace is hibernated", async () => {
+        const secondWorkspace = await workspace.frame.createWorkspace(basicConfig);
+
+        await workspace.hibernate();
+        await workspace.resume();
+    });
+
+
+    it("have the same amount of workspace windows as before being resumed", async () => {
+        await Promise.all(workspace.getAllWindows().map((w) => w.forceLoad()));
+
+        const workspaceWindowsCount = workspace.getAllWindows().length;
+        const secondWorkspace = await workspace.frame.createWorkspace(basicConfig);
+
+        await Promise.all(secondWorkspace.getAllWindows().map((w) => w.forceLoad()));
+        await workspace.hibernate();
+        await workspace.resume();
+        await workspace.refreshReference();
+
+        const workspaceWindowsCountAfterHibernate = workspace.getAllWindows().length;
+
+        expect(workspaceWindowsCount).to.eql(workspaceWindowsCountAfterHibernate);
+    });
+
+    it("have the same amount of columns as before being resumed", async () => {
+        const columnsCount = workspace.getAllColumns().length;
+        const secondWorkspace = await workspace.frame.createWorkspace(basicConfig);
+
+        await workspace.hibernate();
+        await workspace.resume();
+        await workspace.refreshReference();
+
+        const columnsCountAfterHibernate = workspace.getAllColumns().length;
+
+        expect(columnsCount).to.eql(columnsCountAfterHibernate);
+    });
+
+    it("have the same amount of rows as before being resumed", async () => {
+        const rowsCount = workspace.getAllRows().length;
+        const secondWorkspace = await workspace.frame.createWorkspace(basicConfig);
+
+        await workspace.hibernate();
+        await workspace.resume();
+        await workspace.refreshReference();
+
+        const rowsCountAfterHibernate = workspace.getAllRows().length;
+
+        expect(rowsCount).to.eql(rowsCountAfterHibernate);
+    });
+
+    it("have the same amount of groups as before being resumed", async () => {
+        const groupsCount = workspace.getAllGroups().length;
+        const secondWorkspace = await workspace.frame.createWorkspace(basicConfig);
+
+        await workspace.hibernate();
+        await workspace.resume();
+        await workspace.refreshReference();
+
+        const groupsCountAfterHibernate = workspace.getAllGroups().length;
+
+        expect(groupsCount).to.eql(groupsCountAfterHibernate);
+    });
+
+    it("be able to load all windows after being resumed", async () => {
+        const secondWorkspace = await workspace.frame.createWorkspace(basicConfig);
+
+        await workspace.hibernate();
+        await workspace.resume();
+        await workspace.refreshReference();
+
+        await Promise.all(workspace.getAllWindows().map(w => w.forceLoad()));
+    });
+
+    it("not trigger onWindowAdded after being resumed", (done) => {
+        workspace.frame.createWorkspace(basicConfig).then(() => {
+            return gtf.wait(3000, () => { });
+        }).then(() => {
+            return workspace.onWindowAdded(() => {
+                done("Should not resolve");
+            })
+        }).then((unsub) => {
+            gtf.addWindowHook(unsub);
+            return workspace.hibernate();
+        }).then(() => {
+            gtf.wait(3000, () => {
+                done();
+            })
+            return workspace.resume();
+        }).catch(done);
+
+    });
+
+    it("throw an error when the workspace is not hibernated", (done) => {
+        workspace.resume().then(() => {
+            done("Should not resolve");
+        }).catch(() => {
+            done();
+        });
+    });
+
+    it("throw an error when the workspace is resumed twice (sequential)", (done) => {
+        workspace.frame.createWorkspace(basicConfig).then(() => {
+            return workspace.hibernate();
+        }).then(() => {
+            return workspace.resume();
+        }).then(() => {
+            return workspace.resume();
+        }).then(() => {
+            done("Should not resolve");
+        }).catch(() => {
+            done()
+        });
+
+    });
+
+    it("throw an errorwhen the workspace is not selected is resumed twice (parallel)", (done) => {
+        workspace.frame.createWorkspace(basicConfig).then(() => {
+            return workspace.resume();
+        }).then(() => {
+            return Promise.all([workspace.resume(), workspace.resume()]);
+        }).then(() => {
+            done("Should not resolve");
+        }).catch(() => {
+            done()
+        });
+    });
+});

--- a/packages/dev-workspaces-frame/src/App.tsx
+++ b/packages/dev-workspaces-frame/src/App.tsx
@@ -5,6 +5,9 @@ import "@glue42/workspaces-ui-react/dist/styles/goldenlayout-base.css";
 import "@glue42/workspaces-ui-react/dist/styles/glue42-theme.css";
 import "./index.css";
 import { GlueContext } from '@glue42/react-hooks';
+// import { Glue42Workspaces } from '@glue42/workspaces-api';
+// import { Glue42Web } from "@glue42/web";
+// import { Glue42 } from "@glue42/desktop";
 
 const App = () => {
     (window as any).glue = useContext(GlueContext);
@@ -12,5 +15,40 @@ const App = () => {
         <Workspaces />
     );
 }
+
+// const App = () => {
+//     const waitForMyFrame = (glue: Glue42Web.API | Glue42.Glue) => {
+//         return new Promise<Glue42Workspaces.Frame>(async (res, rej) => {
+//             const unsub = await glue.workspaces?.onFrameOpened((f) => {
+//                 if (f.id === getFrameId()) {
+//                     res(f);
+//                     if (unsub) {
+//                         unsub();
+//                     }
+//                 }
+//             });
+//             const frames = await glue.workspaces?.getAllFrames();
+//             const myFrame = frames?.find(f => f.id === getFrameId());
+
+//             if (myFrame) {
+//                 res(myFrame);
+//                 if (unsub) {
+//                     unsub();
+//                 }
+//             }
+//         });
+//     };
+
+//     useGlue(async (glue) => {
+//         const myFrame = await waitForMyFrame(glue as any);
+//         const wsp = (await myFrame.workspaces())[0];
+//         const newWsp = await glue.workspaces?.restoreWorkspace("example2", {title: "example2", reuseWorkspaceId: wsp.id} as any);
+//         await newWsp?.setTitle("Default");
+//     });
+
+//     return (
+//         <Workspaces />
+//     );
+// }
 
 export default App;

--- a/packages/dev-workspaces-frame/src/index.tsx
+++ b/packages/dev-workspaces-frame/src/index.tsx
@@ -79,7 +79,8 @@ ReactDOM.render(
 
       // const platformConfig = {
       //   glue: {
-      //     libraries: [GlueWorkspaces]
+      //     libraries: [GlueWorkspaces],
+      //     systemLogger: { level: "trace" }
       //   },
       //   applications,
       //   layouts,

--- a/packages/web-platform/platform.d.ts
+++ b/packages/web-platform/platform.d.ts
@@ -244,9 +244,24 @@ export namespace Glue42WebPlatform {
     }
 
     export namespace Workspaces {
+        export interface MaximumActiveWorkspacesRule {
+            threshold: number;
+        }
+
+        export interface IdleWorkspacesRule {
+            idleMSThreshold: number;
+        }
+
+        export interface HibernationConfig {
+            maximumActiveWorkspaces?: MaximumActiveWorkspacesRule;
+            idleWorkspaces?: IdleWorkspacesRule;
+        }
+
         export interface Config {
             src: string;
+            hibernation?: HibernationConfig;
             isFrame?: boolean;
+            frameCache?: boolean;
         }
     }
 

--- a/packages/web-platform/src/common/types.ts
+++ b/packages/web-platform/src/common/types.ts
@@ -90,7 +90,7 @@ export interface ApplicationStartConfig {
     waitForAGMReady?: boolean;
 }
 
-export type SystemOperationTypes = "getEnvironment";
+export type SystemOperationTypes = "getEnvironment" | "getBase";
 
 export interface ControlMessage extends Glue42WebPlatform.Plugins.ControlMessage {
     commandId?: string;

--- a/packages/web-platform/src/controllers/system.ts
+++ b/packages/web-platform/src/controllers/system.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Glue42Core } from "@glue42/core";
 import { BridgeOperation, InternalPlatformConfig, LibController, SystemOperationTypes } from "../common/types";
 import { anyDecoder, systemOperationTypesDecoder } from "../shared/decoders";
@@ -5,12 +6,13 @@ import logger from "../shared/logger";
 
 export class SystemController implements LibController {
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private environment: any;
+    private base: any = {};
     private started = false;
 
     private operations: { [key in SystemOperationTypes]: BridgeOperation } = {
-        getEnvironment: { name: "getEnvironment", resultDecoder: anyDecoder, execute: this.handleGetEnvironment.bind(this) }
+        getEnvironment: { name: "getEnvironment", resultDecoder: anyDecoder, execute: this.handleGetEnvironment.bind(this) },
+        getBase: { name: "getBase", resultDecoder: anyDecoder, execute: this.handleGetBase.bind(this) }
     }
 
     private get logger(): Glue42Core.Logger.API | undefined {
@@ -19,6 +21,9 @@ export class SystemController implements LibController {
 
     public async start(config: InternalPlatformConfig): Promise<void> {
         this.environment = config.environment;
+        this.base = {
+            workspacesFrameCache: typeof config.workspaces?.frameCache === "boolean" ? config.workspaces?.frameCache : true
+        };
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -60,8 +65,11 @@ export class SystemController implements LibController {
         return result;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private async handleGetEnvironment(): Promise<any> {
         return this.environment;
+    }
+
+    private async handleGetBase(): Promise<any> {
+        return this.base;
     }
 }

--- a/packages/web-platform/src/libs/workspaces/decoders.ts
+++ b/packages/web-platform/src/libs/workspaces/decoders.ts
@@ -3,7 +3,7 @@
 import { Glue42Workspaces } from "@glue42/workspaces-api";
 import { anyJson, array, boolean, constant, Decoder, intersection, lazy, number, object, oneOf, optional, string } from "decoder-validate";
 import { nonEmptyStringDecoder, nonNegativeNumberDecoder, windowLayoutItemDecoder } from "../../shared/decoders";
-import { AddContainerConfig, AddItemResult, AddWindowConfig, BaseChildSnapshotConfig, BundleConfig, ChildSnapshotResult, ContainerStreamData, ContainerSummaryResult, DeleteLayoutConfig, ExportedLayoutsResult, FrameHello, FrameSnapshotResult, FrameStateConfig, FrameStateResult, FrameStreamData, FrameSummariesResult, FrameSummaryResult, GetFrameSummaryConfig, IsWindowInSwimlaneResult, LayoutSummariesResult, LayoutSummary, MoveFrameConfig, MoveWindowConfig, OpenWorkspaceConfig, ParentSnapshotConfig, PingResult, ResizeItemConfig, SetItemTitleConfig, SimpleItemConfig, SimpleWindowOperationSuccessResult, SwimlaneWindowSnapshotConfig, WindowStreamData, WorkspaceConfigResult, WorkspaceCreateConfigProtocol, WorkspaceEventAction, WorkspaceEventType, WorkspacesLayoutImportConfig, WorkspaceSnapshotResult, WorkspacesOperationsTypes, WorkspaceStreamData, WorkspaceSummariesResult, WorkspaceSummaryResult, WorkspaceWindowData } from "./types";
+import { AddContainerConfig, AddItemResult, AddWindowConfig, BaseChildSnapshotConfig, BundleConfig, ChildSnapshotResult, ContainerStreamData, ContainerSummaryResult, DeleteLayoutConfig, ExportedLayoutsResult, FrameHello, FrameSnapshotResult, FrameStateConfig, FrameStateResult, FrameStreamData, FrameSummariesResult, FrameSummaryResult, GetFrameSummaryConfig, IsWindowInSwimlaneResult, LayoutSummariesResult, LayoutSummary, MoveFrameConfig, MoveWindowConfig, OpenWorkspaceConfig, ParentSnapshotConfig, PingResult, ResizeItemConfig, SetItemTitleConfig, SimpleItemConfig, SimpleWindowOperationSuccessResult, SwimlaneWindowSnapshotConfig, WindowStreamData, WorkspaceConfigResult, WorkspaceCreateConfigProtocol, WorkspaceEventAction, WorkspaceEventType, WorkspaceSelector, WorkspacesLayoutImportConfig, WorkspaceSnapshotResult, WorkspacesOperationsTypes, WorkspaceStreamData, WorkspaceSummariesResult, WorkspaceSummaryResult, WorkspaceWindowData } from "./types";
 
 export const workspacesOperationDecoder: Decoder<WorkspacesOperationsTypes> = oneOf<
     "isWindowInWorkspace" | "createWorkspace" | "getAllFramesSummaries" | "getFrameSummary" |
@@ -11,7 +11,7 @@ export const workspacesOperationDecoder: Decoder<WorkspacesOperationsTypes> = on
     "deleteLayout" | "saveLayout" | "importLayout" | "exportAllLayouts" | "restoreItem" | "maximizeItem" |
     "focusItem" | "closeItem" | "resizeItem" | "moveFrame" | "getFrameSnapshot" | "forceLoadWindow" |
     "ejectWindow" | "setItemTitle" | "moveWindowTo" | "addWindow" | "addContainer" |
-    "bundleWorkspace" | "changeFrameState" | "getFrameState" | "frameHello"
+    "bundleWorkspace" | "changeFrameState" | "getFrameState" | "frameHello" | "hibernateWorkspace" | "resumeWorkspace"
 >(
     constant("isWindowInWorkspace"),
     constant("createWorkspace"),
@@ -41,7 +41,9 @@ export const workspacesOperationDecoder: Decoder<WorkspacesOperationsTypes> = on
     constant("bundleWorkspace"),
     constant("changeFrameState"),
     constant("getFrameState"),
-    constant("frameHello")
+    constant("frameHello"),
+    constant("hibernateWorkspace"),
+    constant("resumeWorkspace")
 );
 
 export const frameHelloDecoder: Decoder<FrameHello> = object({
@@ -277,7 +279,10 @@ export const workspaceConfigResultDecoder: Decoder<WorkspaceConfigResult> = obje
     title: nonEmptyStringDecoder,
     positionIndex: nonNegativeNumberDecoder,
     name: nonEmptyStringDecoder,
-    layoutName: optional(nonEmptyStringDecoder)
+    layoutName: optional(nonEmptyStringDecoder),
+    isHibernated: boolean(),
+    isSelected: boolean(),
+    lastActive: number()
 });
 
 // todo: remove number positionIndex when fixed
@@ -523,6 +528,10 @@ export const bundleConfigDecoder: Decoder<BundleConfig> = object({
         constant("row"),
         constant("column")
     ),
+    workspaceId: nonEmptyStringDecoder
+});
+
+export const workspaceSelectorDecoder: Decoder<WorkspaceSelector> = object({
     workspaceId: nonEmptyStringDecoder
 });
 

--- a/packages/web-platform/src/libs/workspaces/hibernationWatcher.ts
+++ b/packages/web-platform/src/libs/workspaces/hibernationWatcher.ts
@@ -1,0 +1,219 @@
+import { WindowStreamData, WorkspaceConfigResult, WorkspaceEventPayload, WorkspaceSnapshotResult, WorkspaceStreamData } from "./types";
+import { WorkspacesController } from "./controller";
+import { generate } from "shortid";
+import { Glue42WebPlatform } from "../../../platform";
+import logger from "../../shared/logger";
+import { Glue42Web } from "@glue42/web";
+import { SessionStorageController } from "../../controllers/session";
+
+export class WorkspaceHibernationWatcher {
+    private workspacesController!: WorkspacesController;
+    private settings: Glue42WebPlatform.Workspaces.HibernationConfig | undefined;
+    private maximumAmountCheckInProgress = false;
+
+    constructor(private readonly session: SessionStorageController) { }
+
+    private get logger(): Glue42Web.Logger.API | undefined {
+        return logger.get("workspaces.hibernation");
+    }
+
+    public start(workspacesController: WorkspacesController, settings: Glue42WebPlatform.Workspaces.HibernationConfig): void {
+
+        this.logger?.trace(`starting the hibernation watcher with following settings: ${JSON.stringify(this.settings)}`);
+
+        this.workspacesController = workspacesController;
+        this.settings = settings;
+
+        const allTimeoutData = this.session.exportClearTimeouts();
+
+        if (this.settings?.idleWorkspaces?.idleMSThreshold) {
+            allTimeoutData.forEach((timeoutData) => this.buildTimer(timeoutData.workspaceId));
+        }
+
+        this.logger?.trace("The hibernation watcher has started successfully");
+    }
+
+    public notifyEvent(event: WorkspaceEventPayload): void {
+
+        if (event.type === "window") {
+            this.handleWorkspaceWindowEvent(event);
+        }
+
+        if (event.type === "workspace") {
+            this.handleWorkspaceEvent(event);
+        }
+    }
+
+    private handleWorkspaceWindowEvent(event: WorkspaceEventPayload): void {
+        // listens for new windows, in case an empty workspace is no longer empty, therefore adding it to the standard hibernation logic
+        const isWindowOpened = event.action === "opened" || event.action === "added";
+
+        if (!isWindowOpened) {
+            return;
+        }
+
+        this.checkMaximumAmount();
+        this.addTimersForWorkspacesInFrame((event.payload as WindowStreamData).windowSummary.config.frameId);
+    }
+
+    private handleWorkspaceEvent(event: WorkspaceEventPayload): void {
+        const isWorkspaceSelected = event.action === "selected";
+        const workspaceData = event.payload as WorkspaceStreamData;
+
+        if (event.action !== "selected" && event.action !== "opened") {
+            return;
+        }
+
+        this.checkMaximumAmount();
+
+        if (isWorkspaceSelected) {
+            const timeout = this.session.getTimeout(workspaceData.workspaceSummary.id);
+
+            if (timeout) {
+                clearTimeout(timeout);
+                this.session.removeTimeout(workspaceData.workspaceSummary.id);
+            }
+
+            this.addTimersForWorkspacesInFrame(workspaceData.frameSummary.id);
+        }
+    }
+
+    private compare(ws1: WorkspaceSnapshotResult, ws2: WorkspaceSnapshotResult): number {
+        if (ws1.config.lastActive > ws2.config.lastActive) {
+            return 1;
+        }
+        if (ws1.config.lastActive < ws2.config.lastActive) {
+            return -1;
+        }
+        return 0;
+    }
+
+    private async checkMaximumAmount(): Promise<void> {
+        if (this.maximumAmountCheckInProgress) {
+            return;
+        }
+        if (!this.settings?.maximumActiveWorkspaces?.threshold) {
+            return;
+        }
+        this.maximumAmountCheckInProgress = true;
+
+        try {
+            await this.checkMaximumAmountCore(this.settings.maximumActiveWorkspaces.threshold);
+        } finally {
+            this.maximumAmountCheckInProgress = false;
+        }
+    }
+
+    private async checkMaximumAmountCore(threshold: number): Promise<void> {
+        this.logger?.trace(`Checking for maximum active workspaces rule. The threshold is ${this.settings?.maximumActiveWorkspaces?.threshold}`);
+
+        const commandId = generate();
+        const result = await this.workspacesController.getAllWorkspacesSummaries({}, commandId);
+        const snapshotsPromises = result.summaries.map(s => this.workspacesController.getWorkspaceSnapshot({ itemId: s.id }, commandId));
+        const snapshots = await Promise.all(snapshotsPromises);
+
+        const eligibleForHibernation = snapshots.reduce<WorkspaceSnapshotResult[]>((eligible, snapshot) => {
+
+            if (!this.isWorkspaceHibernated(snapshot.config) && !this.isWorkspaceEmpty(snapshot)) {
+                eligible.push(snapshot);
+            }
+
+            return eligible;
+
+        }, [] as WorkspaceSnapshotResult[]);
+
+        if (eligibleForHibernation.length <= threshold) {
+            return;
+        }
+
+        this.logger?.trace(`Found ${eligibleForHibernation.length} eligible for hibernation workspaces`);
+
+        const hibernationPromises = eligibleForHibernation
+            .sort(this.compare)
+            .slice(0, eligibleForHibernation.length - threshold)
+            .map((w) => this.tryHibernateWorkspace(w.id));
+
+        await Promise.all(hibernationPromises);
+    }
+
+    private async tryHibernateWorkspace(workspaceId: string): Promise<void> {
+        try {
+            const snapshot = await this.workspacesController.getWorkspaceSnapshot({ itemId: workspaceId }, generate());
+
+            if (!this.canBeHibernated(snapshot)) {
+                return;
+            }
+
+            this.logger?.trace(`trying to hibernate workspace ${workspaceId}`);
+
+            await this.workspacesController.hibernateWorkspace({ workspaceId }, generate());
+
+            this.logger?.trace(`workspace ${workspaceId} was hibernated successfully`);
+        } catch (error) {
+            this.logger?.trace(error);
+        }
+    }
+
+    private canBeHibernated(snapshot: WorkspaceSnapshotResult): boolean {
+        const isWorkspaceHibernated = this.isWorkspaceHibernated(snapshot.config);
+        const isWorkspaceSelected = this.isWorkspaceSelected(snapshot.config);
+        const isWorkspaceEmpty = this.isWorkspaceEmpty(snapshot);
+
+        return !isWorkspaceHibernated && !isWorkspaceSelected && !isWorkspaceEmpty;
+    }
+
+    private isWorkspaceHibernated(workspaceSnapshot: WorkspaceConfigResult): boolean {
+        return workspaceSnapshot.isHibernated;
+    }
+
+    private isWorkspaceSelected(workspaceSnapshot: WorkspaceConfigResult): boolean {
+        return workspaceSnapshot.isSelected;
+    }
+
+    private isWorkspaceEmpty(workspaceSnapshot: WorkspaceSnapshotResult): boolean {
+        return !workspaceSnapshot.children.length;
+    }
+
+    private async getWorkspacesInFrame(frameId: string): Promise<WorkspaceSnapshotResult[]> {
+        const result = await this.workspacesController.getAllWorkspacesSummaries({}, generate());
+
+        const snapshotPromises = result.summaries.reduce((promises, summary) => {
+            if (summary.config.frameId === frameId) {
+                promises.push(this.workspacesController.getWorkspaceSnapshot({ itemId: summary.id }, generate()));
+            }
+
+            return promises;
+        }, [] as Array<Promise<WorkspaceSnapshotResult>>);
+
+        return await Promise.all(snapshotPromises);
+    }
+
+    private async addTimersForWorkspacesInFrame(frameId: string): Promise<void> {
+        if (!this.settings?.idleWorkspaces?.idleMSThreshold) {
+            return;
+        }
+
+        const workspacesInFrame = await this.getWorkspacesInFrame(frameId);
+
+        workspacesInFrame.map((w) => {
+
+            if (!this.canBeHibernated(w) || this.session.getTimeout(w.id)) {
+                return;
+            }
+
+            this.buildTimer(w.id);
+
+            this.logger?.trace(`Starting workspace idle timer ( ${this.settings?.idleWorkspaces?.idleMSThreshold}ms ) for workspace ${w.id}`);
+        });
+    }
+
+    private buildTimer(workspaceId: string): void {
+        const timeout = setTimeout(() => {
+            this.logger?.trace(`Timer triggered will try to hibernated ${workspaceId}`);
+            this.tryHibernateWorkspace(workspaceId);
+            this.session.removeTimeout(workspaceId);
+        }, this.settings?.idleWorkspaces?.idleMSThreshold);
+
+        this.session.saveTimeout(workspaceId, timeout);
+    }
+}

--- a/packages/web-platform/src/libs/workspaces/types.ts
+++ b/packages/web-platform/src/libs/workspaces/types.ts
@@ -13,7 +13,11 @@ export interface WorkspaceWindowData {
 export type WorkspaceEventType = "frame" | "workspace" | "container" | "window";
 export type WorkspaceEventScope = "global" | "frame" | "workspace" | "window";
 export type WorkspaceEventAction = "opened" | "closing" | "closed" | "focus" | "added" | "loaded" | "removed" | "childrenUpdate" | "containerChange" | "maximized" | "minimized" | "normal" | "selected";
-export type WorkspacePayload = FrameStreamData | WorkspaceStreamData | ContainerStreamData | WindowStreamData;
+export interface WorkspaceEventPayload {
+    action: WorkspaceEventAction;
+    type: WorkspaceEventType;
+    payload: FrameStreamData | WorkspaceStreamData | ContainerStreamData | WindowStreamData;
+}
 
 export type WorkspacesOperationsTypes = "isWindowInWorkspace" |
     "createWorkspace" |
@@ -43,7 +47,9 @@ export type WorkspacesOperationsTypes = "isWindowInWorkspace" |
     "bundleWorkspace" |
     "changeFrameState" |
     "getFrameState" |
-    "frameHello";
+    "frameHello" |
+    "hibernateWorkspace" |
+    "resumeWorkspace";
 
 export interface FrameQueryConfig {
     frameId?: string;
@@ -85,6 +91,9 @@ export interface WorkspaceConfigResult {
     name: string;
     positionIndex: number;
     layoutName: string | undefined;
+    isSelected: boolean;
+    isHibernated: boolean;
+    lastActive: number;
 }
 
 export interface BaseChildSnapshotConfig {
@@ -246,6 +255,11 @@ export interface BundleConfig {
     type: "row" | "column";
     workspaceId: string;
 }
+
+export interface WorkspaceSelector {
+    workspaceId: string;
+}
+
 // #endregion
 
 export interface FrameStreamData {

--- a/packages/web-platform/src/platform.ts
+++ b/packages/web-platform/src/platform.ts
@@ -56,7 +56,8 @@ export class Platform {
         const glue42core = {
             platformStarted: true,
             isPlatformFrame: !!config?.workspaces?.isFrame,
-            environment: this.platformConfig.environment
+            environment: this.platformConfig.environment,
+            workspacesFrameCache: typeof config.workspaces?.frameCache === "boolean" ? config.workspaces?.frameCache : true
         };
 
         (window as any).glue42core = glue42core;

--- a/packages/web-platform/src/shared/decoders.ts
+++ b/packages/web-platform/src/shared/decoders.ts
@@ -80,8 +80,9 @@ export const libDomainDecoder: Decoder<LibDomains> = oneOf<"system" | "windows" 
     constant("intents")
 );
 
-export const systemOperationTypesDecoder: Decoder<SystemOperationTypes> = oneOf<"getEnvironment">(
-    constant("getEnvironment")
+export const systemOperationTypesDecoder: Decoder<SystemOperationTypes> = oneOf<"getEnvironment" | "getBase">(
+    constant("getEnvironment"),
+    constant("getBase")
 );
 
 export const windowLayoutItemDecoder: Decoder<Glue42Workspaces.WindowLayoutItem> = object({
@@ -261,9 +262,24 @@ export const gatewayConfigDecoder: Decoder<Glue42WebPlatform.Gateway.Config> = o
 // todo: proper implement when the config has been finalized
 export const glueConfigDecoder: Decoder<Glue42Web.Config> = anyJson();
 
+export const maximumActiveWorkspacesDecoder: Decoder<Glue42WebPlatform.Workspaces.MaximumActiveWorkspacesRule> = object({
+    threshold: number().where((num) => num > 1, "Expected a number larger than 1")
+});
+
+export const idleWorkspacesDecoder: Decoder<Glue42WebPlatform.Workspaces.IdleWorkspacesRule> = object({
+    idleMSThreshold: number().where((num) => num > 100, "Expected a number larger than 100")
+});
+
+export const hibernationConfigDecoder: Decoder<Glue42WebPlatform.Workspaces.HibernationConfig> = object({
+    maximumActiveWorkspaces: optional(maximumActiveWorkspacesDecoder),
+    idleWorkspaces: optional(idleWorkspacesDecoder)
+});
+
 export const workspacesConfigDecoder: Decoder<Glue42WebPlatform.Workspaces.Config> = object({
     src: nonEmptyStringDecoder,
-    isFrame: optional(boolean())
+    hibernation: optional(hibernationConfigDecoder),
+    isFrame: optional(boolean()),
+    frameCache: optional(boolean())
 });
 
 export const windowsConfigDecoder: Decoder<Glue42WebPlatform.Windows.Config> = object({

--- a/packages/web-platform/src/shared/ioc.ts
+++ b/packages/web-platform/src/shared/ioc.ts
@@ -14,6 +14,7 @@ import { WorkspacesController } from "../libs/workspaces/controller";
 import { IntentsController } from "../libs/intents/controller";
 import { ChannelsController } from "../libs/channels/controller";
 import { FramesController } from "../libs/workspaces/frames";
+import { WorkspaceHibernationWatcher } from "../libs/workspaces/hibernationWatcher";
 import { SystemController } from "../controllers/system";
 import { AppDirectory } from "../libs/applications/appStore/directory";
 import { RemoteWatcher } from "../libs/applications/appStore/remoteWatcher";
@@ -30,6 +31,7 @@ export class IoC {
     private _remoteWatcher!: RemoteWatcher;
     private _layoutsController!: LayoutsController;
     private _workspacesController!: WorkspacesController;
+    private _hibernationWatcher!: WorkspaceHibernationWatcher;
     private _intentsController!: IntentsController;
     private _channelsController!: ChannelsController;
     private _sessionController!: SessionStorageController;
@@ -167,11 +169,20 @@ export class IoC {
                 this.framesController,
                 this.glueController,
                 this.stateController,
+                this.hibernationWatcher,
                 this
             );
         }
 
         return this._workspacesController;
+    }
+
+    public get hibernationWatcher(): WorkspaceHibernationWatcher {
+        if (!this._hibernationWatcher) {
+            this._hibernationWatcher = new WorkspaceHibernationWatcher(this.sessionController);
+        }
+
+        return this._hibernationWatcher;
     }
 
     public get intentsController(): IntentsController {

--- a/packages/web/src/system/controller.ts
+++ b/packages/web/src/system/controller.ts
@@ -22,7 +22,10 @@ export class SystemController implements LibController {
         const environment = await this.bridge.send<void, any>("system", operations.getEnvironment, undefined);
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const glue42core = Object.assign({}, (window as any).glue42core, { environment });
+        const base = await this.bridge.send<void, any>("system", operations.getBase, undefined);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const glue42core = Object.assign({}, (window as any).glue42core, base, { environment });
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (window as any).glue42core = Object.freeze(glue42core);

--- a/packages/web/src/system/protocol.ts
+++ b/packages/web/src/system/protocol.ts
@@ -1,8 +1,9 @@
 import { anyDecoder } from "../shared/decoders";
 import { BridgeOperation } from "../shared/types";
 
-export type SystemOperationTypes = "getEnvironment";
+export type SystemOperationTypes = "getEnvironment" | "getBase";
 
 export const operations: { [key in SystemOperationTypes]: BridgeOperation } = {
-    getEnvironment: { name: "getEnvironment", resultDecoder: anyDecoder }
+    getEnvironment: { name: "getEnvironment", resultDecoder: anyDecoder },
+    getBase: { name: "getBase", resultDecoder: anyDecoder }
 };

--- a/packages/workspaces-api/src/communication/bridge.ts
+++ b/packages/workspaces-api/src/communication/bridge.ts
@@ -59,7 +59,7 @@ export class Bridge {
             try {
                 operationDefinition.argsDecoder.runWithException(operationArgs);
             } catch (error) {
-                throw new Error(`Unexpected internal outgoing validation error: ${error.message}, for input: ${JSON.stringify(error.input)}`);
+                throw new Error(`Unexpected internal outgoing validation error: ${error.message}, for input: ${JSON.stringify(error.input)}, for operation ${operationName}`);
             }
         }
 
@@ -70,7 +70,7 @@ export class Bridge {
             operationResult = operationDefinition.resultDecoder.runWithException(operationResultRaw);
         } catch (error) {
             if (error.kind) {
-                throw new Error(`Unexpected internal incoming validation error: ${error.message}, for input: ${JSON.stringify(error.input)}`);
+                throw new Error(`Unexpected internal incoming validation error: ${error.message}, for input: ${JSON.stringify(error.input)}, for operation ${operationName}`);
             }
             throw new Error(error.message);
         }
@@ -166,9 +166,9 @@ export class Bridge {
             const verifiedAction: WorkspaceEventAction = workspaceEventActionDecoder.runWithException(data.action);
             const verifiedType: WorkspaceEventType = eventTypeDecoder.runWithException(data.type);
             const verifiedPayload: WorkspacePayload = STREAMS[verifiedType].payloadDecoder.runWithException(data.payload);
-    
+
             const registryKey = `${verifiedType}-${verifiedAction}`;
-    
+
             this.registry.execute(registryKey, verifiedPayload);
         } catch (error) {
             console.warn(`Cannot handle event with data ${JSON.stringify(data)}, because of validation error: ${error.message}`);

--- a/packages/workspaces-api/src/communication/constants.ts
+++ b/packages/workspaces-api/src/communication/constants.ts
@@ -1,4 +1,4 @@
-import { isWindowInSwimlaneResultDecoder, frameSummaryDecoder, workspaceSnapshotResultDecoder, frameSummariesResultDecoder, workspaceCreateConfigDecoder, getFrameSummaryConfigDecoder, layoutSummariesDecoder, openWorkspaceConfigDecoder, workspaceSummariesResultDecoder, voidResultDecoder, exportedLayoutsResultDecoder, workspaceLayoutDecoder, deleteLayoutConfigDecoder, simpleItemConfigDecoder, resizeItemConfigDecoder, moveFrameConfigDecoder, frameSnapshotResultDecoder, simpleWindowOperationSuccessResultDecoder, setItemTitleConfigDecoder, moveWindowConfigDecoder, addWindowConfigDecoder, addContainerConfigDecoder, addItemResultDecoder, bundleConfigDecoder, workspaceStreamDataDecoder, frameStreamDataDecoder, containerStreamDataDecoder, windowStreamDataDecoder, workspaceLayoutSaveConfigDecoder, pingResultDecoder, frameStateConfigDecoder, frameStateResultDecoder, workspacesImportLayoutDecoder } from "../shared/decoders";
+import { isWindowInSwimlaneResultDecoder, frameSummaryDecoder, workspaceSnapshotResultDecoder, frameSummariesResultDecoder, workspaceCreateConfigDecoder, getFrameSummaryConfigDecoder, layoutSummariesDecoder, openWorkspaceConfigDecoder, workspaceSummariesResultDecoder, voidResultDecoder, exportedLayoutsResultDecoder, workspaceLayoutDecoder, deleteLayoutConfigDecoder, simpleItemConfigDecoder, resizeItemConfigDecoder, moveFrameConfigDecoder, frameSnapshotResultDecoder, simpleWindowOperationSuccessResultDecoder, setItemTitleConfigDecoder, moveWindowConfigDecoder, addWindowConfigDecoder, addContainerConfigDecoder, addItemResultDecoder, bundleConfigDecoder, workspaceStreamDataDecoder, frameStreamDataDecoder, containerStreamDataDecoder, windowStreamDataDecoder, workspaceLayoutSaveConfigDecoder, pingResultDecoder, frameStateConfigDecoder, frameStateResultDecoder, workspacesImportLayoutDecoder, workspaceSelectorDecoder } from "../shared/decoders";
 import { ControlOperation, StreamOperation } from "../types/protocol";
 import { WorkspaceEventType } from "../types/subscription";
 
@@ -29,8 +29,10 @@ type OperationsTypes = "isWindowInWorkspace" |
     "addContainer" |
     "bundleWorkspace" |
     "ping" |
-    "changeFrameState" | 
-    "getFrameState";
+    "changeFrameState" |
+    "getFrameState" |
+    "hibernateWorkspace" |
+    "resumeWorkspace";
 type MethodsTypes = "control" | "frameStream" | "workspaceStream" | "containerStream" | "windowStream";
 
 export const webPlatformMethodName = "T42.Web.Platform.Control";
@@ -52,7 +54,7 @@ export const STREAMS: { [key in WorkspaceEventType]: StreamOperation } = {
 };
 
 export const OPERATIONS: { [key in OperationsTypes]: ControlOperation } = {
-    ping: { name: "ping", resultDecoder: pingResultDecoder},
+    ping: { name: "ping", resultDecoder: pingResultDecoder },
     isWindowInWorkspace: { name: "isWindowInWorkspace", argsDecoder: simpleItemConfigDecoder, resultDecoder: isWindowInSwimlaneResultDecoder },
     createWorkspace: { name: "createWorkspace", resultDecoder: workspaceSnapshotResultDecoder, argsDecoder: workspaceCreateConfigDecoder },
     getAllFramesSummaries: { name: "getAllFramesSummaries", resultDecoder: frameSummariesResultDecoder },
@@ -70,8 +72,8 @@ export const OPERATIONS: { [key in OperationsTypes]: ControlOperation } = {
     focusItem: { name: "focusItem", argsDecoder: simpleItemConfigDecoder, resultDecoder: voidResultDecoder },
     closeItem: { name: "closeItem", argsDecoder: simpleItemConfigDecoder, resultDecoder: voidResultDecoder },
     resizeItem: { name: "resizeItem", argsDecoder: resizeItemConfigDecoder, resultDecoder: voidResultDecoder },
-    changeFrameState: {name: "changeFrameState", argsDecoder: frameStateConfigDecoder, resultDecoder: voidResultDecoder},
-    getFrameState: {name: "getFrameState", argsDecoder: simpleItemConfigDecoder, resultDecoder: frameStateResultDecoder},
+    changeFrameState: { name: "changeFrameState", argsDecoder: frameStateConfigDecoder, resultDecoder: voidResultDecoder },
+    getFrameState: { name: "getFrameState", argsDecoder: simpleItemConfigDecoder, resultDecoder: frameStateResultDecoder },
     moveFrame: { name: "moveFrame", argsDecoder: moveFrameConfigDecoder, resultDecoder: voidResultDecoder },
     getFrameSnapshot: { name: "getFrameSnapshot", argsDecoder: simpleItemConfigDecoder, resultDecoder: frameSnapshotResultDecoder },
     forceLoadWindow: { name: "forceLoadWindow", argsDecoder: simpleItemConfigDecoder, resultDecoder: simpleWindowOperationSuccessResultDecoder },
@@ -80,5 +82,7 @@ export const OPERATIONS: { [key in OperationsTypes]: ControlOperation } = {
     moveWindowTo: { name: "moveWindowTo", argsDecoder: moveWindowConfigDecoder, resultDecoder: voidResultDecoder },
     addWindow: { name: "addWindow", argsDecoder: addWindowConfigDecoder, resultDecoder: addItemResultDecoder },
     addContainer: { name: "addContainer", argsDecoder: addContainerConfigDecoder, resultDecoder: addItemResultDecoder },
-    bundleWorkspace: { name: "bundleWorkspace", argsDecoder: bundleConfigDecoder, resultDecoder: voidResultDecoder }
+    bundleWorkspace: { name: "bundleWorkspace", argsDecoder: bundleConfigDecoder, resultDecoder: voidResultDecoder },
+    hibernateWorkspace: { name: "hibernateWorkspace", argsDecoder: workspaceSelectorDecoder, resultDecoder: voidResultDecoder },
+    resumeWorkspace: { name: "resumeWorkspace", argsDecoder: workspaceSelectorDecoder, resultDecoder: voidResultDecoder },
 };

--- a/packages/workspaces-api/src/controllers/base.ts
+++ b/packages/workspaces-api/src/controllers/base.ts
@@ -363,4 +363,13 @@ export class BaseController {
             });
         });
     }
+
+    public async hibernateWorkspace(workspaceId: string): Promise<void> {
+        await this.bridge.send<void>(OPERATIONS.hibernateWorkspace.name, { workspaceId });
+    }
+
+    public async resumeWorkspace(workspaceId: string): Promise<void> {
+        await this.bridge.send<void>(OPERATIONS.resumeWorkspace.name, { workspaceId });
+
+    }
 }

--- a/packages/workspaces-api/src/controllers/main.ts
+++ b/packages/workspaces-api/src/controllers/main.ts
@@ -314,6 +314,14 @@ export class MainController implements WorkspacesController {
         return this.base.iterateFilterChildren(children, predicate);
     }
 
+    public hibernateWorkspace(workspaceId: string): Promise<void> {
+        return this.base.hibernateWorkspace(workspaceId);
+    }
+
+    public resumeWorkspace(workspaceId: string): Promise<void> {
+        return this.base.resumeWorkspace(workspaceId);
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     private async handleCoreLocalSubscription(config: SubscriptionConfig, levelId: string): Promise<Glue42Workspaces.Unsubscribe> {
         await this.bridge.createCoreEventSubscription();

--- a/packages/workspaces-api/src/models/workspace.ts
+++ b/packages/workspaces-api/src/models/workspace.ts
@@ -52,6 +52,10 @@ export class Workspace implements Glue42Workspaces.Workspace {
         return getData(this).config.layoutName;
     }
 
+    public get isHibernated(): boolean {
+        return getData(this).config.isHibernated;
+    }
+
     public get children(): Glue42Workspaces.WorkspaceElement[] {
         return getData(this).children;
     }
@@ -106,7 +110,7 @@ export class Workspace implements Glue42Workspaces.Workspace {
 
     public async saveLayout(name: string, config?: { saveContext?: boolean }): Promise<void> {
         nonEmptyStringDecoder.runWithException(name);
-        await getData(this).controller.saveLayout({name, workspaceId: this.id, saveContext: config?.saveContext});
+        await getData(this).controller.saveLayout({ name, workspaceId: this.id, saveContext: config?.saveContext });
     }
 
     public async setTitle(title: string): Promise<void> {
@@ -289,6 +293,16 @@ export class Workspace implements Glue42Workspaces.Workspace {
 
     public async bundleToColumn(): Promise<void> {
         await getData(this).controller.bundleTo("column", this.id);
+        await this.refreshReference();
+    }
+
+    public async hibernate(): Promise<void> {
+        await getData(this).controller.hibernateWorkspace(this.id);
+        await this.refreshReference();
+    }
+
+    public async resume(): Promise<void> {
+        await getData(this).controller.resumeWorkspace(this.id);
         await this.refreshReference();
     }
 

--- a/packages/workspaces-api/src/shared/decoders.ts
+++ b/packages/workspaces-api/src/shared/decoders.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import { Decoder, object, boolean, string, optional, array, oneOf, constant, lazy, number, anyJson, intersection } from "decoder-validate";
-import { IsWindowInSwimlaneResult, WorkspaceSnapshotResult, ChildSnapshotResult, WorkspaceConfigResult, FrameSummaryResult, WorkspaceCreateConfigProtocol, GetFrameSummaryConfig, WorkspaceSummaryResult, LayoutSummariesResult, LayoutSummary, OpenWorkspaceConfig, FrameSummariesResult, WorkspaceSummariesResult, ExportedLayoutsResult, DeleteLayoutConfig, SimpleItemConfig, ResizeItemConfig, MoveFrameConfig, FrameSnapshotResult, BaseChildSnapshotConfig, ParentSnapshotConfig, SwimlaneWindowSnapshotConfig, SimpleWindowOperationSuccessResult, SetItemTitleConfig, MoveWindowConfig, AddWindowConfig, AddContainerConfig, AddItemResult, BundleConfig, WorkspaceStreamData, FrameStreamData, ContainerStreamData, ContainerSummaryResult, WindowStreamData, PingResult, FrameStateConfig, FrameStateResult } from "../types/protocol";
+import { IsWindowInSwimlaneResult, WorkspaceSnapshotResult, ChildSnapshotResult, WorkspaceConfigResult, FrameSummaryResult, WorkspaceCreateConfigProtocol, GetFrameSummaryConfig, WorkspaceSummaryResult, LayoutSummariesResult, LayoutSummary, OpenWorkspaceConfig, FrameSummariesResult, WorkspaceSummariesResult, ExportedLayoutsResult, DeleteLayoutConfig, SimpleItemConfig, ResizeItemConfig, MoveFrameConfig, FrameSnapshotResult, BaseChildSnapshotConfig, ParentSnapshotConfig, SwimlaneWindowSnapshotConfig, SimpleWindowOperationSuccessResult, SetItemTitleConfig, MoveWindowConfig, AddWindowConfig, AddContainerConfig, AddItemResult, BundleConfig, WorkspaceStreamData, FrameStreamData, ContainerStreamData, ContainerSummaryResult, WindowStreamData, PingResult, FrameStateConfig, FrameStateResult, WorkspaceSeletor } from "../types/protocol";
 import { WorkspaceEventType, WorkspaceEventAction } from "../types/subscription";
 import { Glue42Workspaces } from "../../workspaces";
 
@@ -229,7 +229,9 @@ export const workspaceConfigResultDecoder: Decoder<WorkspaceConfigResult> = obje
     title: nonEmptyStringDecoder,
     positionIndex: nonNegativeNumberDecoder,
     name: nonEmptyStringDecoder,
-    layoutName: optional(nonEmptyStringDecoder)
+    layoutName: optional(nonEmptyStringDecoder),
+    isHibernated: boolean(),
+    isSelected: boolean(),
 });
 
 // todo: remove number positionIndex when fixed
@@ -506,4 +508,8 @@ export const workspaceLayoutSaveConfigDecoder: Decoder<Glue42Workspaces.Workspac
     name: nonEmptyStringDecoder,
     workspaceId: nonEmptyStringDecoder,
     saveContext: optional(boolean())
+});
+
+export const workspaceSelectorDecoder: Decoder<WorkspaceSeletor> = object({
+    workspaceId: nonEmptyStringDecoder,
 });

--- a/packages/workspaces-api/src/types/controller.ts
+++ b/packages/workspaces-api/src/types/controller.ts
@@ -51,4 +51,6 @@ export interface WorkspacesController {
     refreshChildren(config: RefreshChildrenConfig): Child[];
     iterateFindChild(children: Child[], predicate: (child: Child) => boolean): Child;
     iterateFilterChildren(children: Child[], predicate: (child: Child) => boolean): Child[];
+    hibernateWorkspace(workspaceId: string): Promise<void>;
+    resumeWorkspace(workspaceId: string): Promise<void>;
 }

--- a/packages/workspaces-api/src/types/protocol.ts
+++ b/packages/workspaces-api/src/types/protocol.ts
@@ -24,6 +24,7 @@ export interface WorkspaceConfigResult {
     name: string;
     positionIndex: number;
     layoutName: string | undefined;
+    isHibernated: boolean;
 }
 
 export interface BaseChildSnapshotConfig {
@@ -185,6 +186,11 @@ export interface BundleConfig {
     type: "row" | "column";
     workspaceId: string;
 }
+
+export interface WorkspaceSeletor {
+    workspaceId: string;
+}
+
 // #endregion
 
 // #region stream incoming

--- a/packages/workspaces-api/workspaces.d.ts
+++ b/packages/workspaces-api/workspaces.d.ts
@@ -115,6 +115,9 @@ export namespace Glue42Workspaces {
 
         /** A setting used to declare that the workspace must be in a new frame and also provide options for that new frame */
         newFrame?: NewFrameConfig | boolean;
+
+        /** Used for replacing the specified workspace instead of creating a new one */
+        reuseWorkspaceId?: string;
     }
 
     /** An object describing the possible settings when defining a new frame. */
@@ -187,6 +190,9 @@ export namespace Glue42Workspaces {
 
         /** Provides the opportunity to open a workspace with no tab header */
         noTabHeader?: boolean;
+
+        /** Used for replacing the specified workspace instead of creating a new one */
+        reuseWorkspaceId?: string;
     }
 
     /** An object describing the possible options when defining a new workspace */

--- a/packages/workspaces-ui-core/assets/css/goldenlayout-base.css
+++ b/packages/workspaces-ui-core/assets/css/goldenlayout-base.css
@@ -376,6 +376,17 @@ ul {
   height: 12px;
   content: "";
 }
+.lm_hibernationIcon {
+  margin-right: 6px;
+  border-radius: none;
+  transition: none;
+}
+.lm_hibernationIcon::before {
+  mask-image: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' x='0px' y='0px' viewBox='0 0 64 64' xml:space='preserve'%3E%3Cpath d='M37.7,38.8v-4.2l16.1-23v-0.2H39.2V5h24.6v4.5L48,32.2v0.2h16v6.4H37.7z M17,50v-2.7l10.4-14.9v-0.1H18v-4.2h15.9v2.9 L23.7,45.7v0.1h10.4V50H17z M0,59v-2l7.6-10.8v-0.1H0.7v-3h11.6v2.1L4.8,55.9V56h7.5v3H0z'/%3E%3C/svg%3E%0A");
+  width: 12px;
+  height: 12px;
+  content: "";
+}
 .lm_close_tab {
   position: absolute;
   right: 6px;

--- a/packages/workspaces-ui-core/src/app/factory.ts
+++ b/packages/workspaces-ui-core/src/app/factory.ts
@@ -1,0 +1,268 @@
+import GoldenLayout from "@glue42/golden-layout";
+import { Glue42Web } from "@glue42/web";
+import { generate } from "shortid";
+import { WorkspacesManager } from "../manager";
+import { EmptyVisibleWindowName, PlatformControlMethod } from "../constants";
+import { IFrameController } from "../iframeController";
+import { LayoutStateResolver } from "../layout/stateResolver";
+import store from "../store";
+import { getElementBounds, idAsString } from "../utils";
+import createRegistry from "callback-registry";
+import { Window, WindowSummary } from "../types/internal";
+
+export class ApplicationFactory {
+    private readonly registry = createRegistry();
+    private readonly WAIT_FOR_WINDOWS_TIMEOUT = 30000;
+
+    constructor(
+        private readonly _glue: Glue42Web.API,
+        private readonly _stateResolver: LayoutStateResolver,
+        private readonly _frameController: IFrameController,
+        private readonly _manager: WorkspacesManager,
+    ) { }
+
+    public async start(component: GoldenLayout.Component, workspaceId: string) {
+        if (component.config.componentName === EmptyVisibleWindowName) {
+            return;
+        }
+        const workspace = store.getById(workspaceId);
+        const newWindowBounds = getElementBounds(component.element);
+        const { componentState } = component.config;
+        const { title, appName } = componentState;
+        let { windowId } = componentState;
+        const componentId = idAsString(component.config.id);
+        const applicationTitle = this.getTitleByAppName(appName);
+        const windowTitle = this.vaidateTitle(title) || this.vaidateTitle(applicationTitle) || this.vaidateTitle(appName) || "Glue";
+        const windowContext = component?.config.componentState?.context;
+        let url = this.getUrlByAppName(componentState.appName) || componentState.url;
+
+        const isNewWindow = !store.getWindow(componentId);
+        const isHibernatedWindow = workspace.hibernatedWindows.some(w => w.id === idAsString(component.config.id));
+
+        store.addWindow({
+            id: componentId,
+            bounds: newWindowBounds,
+            windowId,
+            url,
+            appName
+        }, workspace.id);
+
+        if (!url && windowId) {
+            const win = this._glue.windows.list().find((w) => w.id === windowId);
+
+            url = await win.getURL();
+            const newlyAddedWindow = store.getWindow(componentId) as Window;
+
+            newlyAddedWindow.url = url;
+        }
+
+        windowId = windowId || generate();
+
+        if (component.config.componentState?.context) {
+            delete component.config.componentState.context;
+        }
+
+        component.config.componentState.url = url;
+        if (windowTitle) {
+            component.setTitle(windowTitle);
+        }
+        if (isNewWindow && !isHibernatedWindow) {
+            const windowSummary = this._stateResolver.getWindowSummarySync(componentId, component);
+            this._manager.workspacesEventEmitter.raiseWindowEvent({
+                action: "added",
+                payload: {
+                    windowSummary
+                }
+            });
+
+            const glueWinOutsideOfWorkspace = this._glue.windows.findById(windowId);
+            if (glueWinOutsideOfWorkspace) {
+                try {
+                    // Glue windows with the given id should be closed
+                    await glueWinOutsideOfWorkspace.close();
+                } catch (error) {
+                    // because of chrome security policy this call can fail,
+                    // however the opening of a new window should continue
+                }
+            }
+        }
+
+        try {
+            await this.notifyFrameWillStart(windowId, appName, windowContext, windowTitle);
+            await this._frameController.startFrame(componentId, url, undefined, windowId);
+            const newlyAddedWindow = store.getWindow(componentId) as Window;
+
+            component.config.componentState.windowId = windowId;
+            newlyAddedWindow.windowId = windowId;
+
+            const newlyOpenedWindow = this._glue.windows.findById(windowId);
+            newlyOpenedWindow.getTitle().then((winTitle) => {
+                if (this.vaidateTitle(windowTitle)) {
+                    component.setTitle(winTitle);
+                }
+            }).catch((e) => {
+                console.warn("Failed while setting the window title", e);
+            });
+
+            this._frameController.moveFrame(componentId, getElementBounds(component.element));
+
+            if (isNewWindow && !isHibernatedWindow) {
+                this._manager.workspacesEventEmitter.raiseWindowEvent({
+                    action: "loaded",
+                    payload: {
+                        windowSummary: await this._stateResolver.getWindowSummary(componentId)
+                    }
+                });
+            }
+
+            if (!appName) {
+                const appNameToUse = this.getAppNameByWindowId(windowId);
+                if (!component.config.componentState) {
+                    throw new Error(`Invalid state - the created component ${componentId} with windowId ${windowId} is missing its state object`);
+                }
+                component.config.componentState.appName = appNameToUse;
+
+
+                newlyAddedWindow.appName = appNameToUse;
+            }
+
+        } catch (error) {
+            this.raiseFailed(component, workspaceId);
+            // If a frame doesn't initialize properly remove its windowId
+            component.config.componentState.windowId = undefined;
+            if (url) {
+                this._frameController.moveFrame(componentId, getElementBounds(component.element));
+            } else {
+                this._manager.closeTab(component, false);
+            }
+            const wsp = store.getById(workspaceId);
+            if (!wsp) {
+                throw new Error(`Workspace ${workspaceId} failed ot initialize because none of the specified windows were able to load
+                Internal error: ${error}`);
+            }
+        } finally {
+            workspace.hibernatedWindows = workspace.hibernatedWindows.filter((hw) => hw.id !== idAsString(component.config.id));
+        }
+    }
+
+    public notifyFrameWillClose(windowId: string, appName?: string) {
+        return this._glue.interop.invoke(PlatformControlMethod, {
+            domain: appName ? "appManager" : "windows",
+            operation: appName ? "unregisterWorkspaceApp" : "unregisterWorkspaceWindow",
+            data: {
+                windowId,
+            }
+        });
+    }
+
+    public onStarted(callback: (args: { summary: WindowSummary }) => void) {
+        return this.registry.add("on-started", callback);
+    }
+
+    public onLoaded(callback: (args: { summary: WindowSummary }) => void) {
+        return this.registry.add("on-loaded", callback);
+    }
+
+    public onFailed(callback: (args: { component: GoldenLayout.Component, workspaceId: string }) => void) {
+        return this.registry.add("on-failed", callback);
+    }
+
+    public waitForWindows(workspaceId: string, windowComponentIds: string[]) {
+        return new Promise<void>((res, rej) => {
+            let loadedUnsub = () => { };
+            let failedUnsub = () => { };
+            let timeout: NodeJS.Timeout;
+
+
+            const [ready, result] = this.waitFor(windowComponentIds.length, () => {
+                res();
+                loadedUnsub();
+                failedUnsub();
+                clearTimeout(timeout);
+            });
+
+            timeout = setTimeout(() => {
+                rej(`Waiting for windows ${JSON.stringify(windowComponentIds)} in workspace ${workspaceId}, but only heard ${JSON.stringify(result())} in ${this.WAIT_FOR_WINDOWS_TIMEOUT} seconds`)
+            }, this.WAIT_FOR_WINDOWS_TIMEOUT);
+
+            loadedUnsub = this.onLoaded(({ summary }) => {
+                if (summary.config.workspaceId === workspaceId && windowComponentIds.includes(summary.itemId)) {
+                    ready(summary.itemId);
+                }
+            });
+
+            failedUnsub = this.onFailed((args) => {
+                if (args.workspaceId === workspaceId && windowComponentIds.includes(idAsString(args.component.config.id))) {
+                    ready(args.component.config.id);
+                }
+            });
+        });
+    }
+
+    public getUrlByAppName(appName: string): string {
+        if (!appName) {
+            return undefined;
+        }
+        return this._glue.appManager?.application(appName)?.userProperties?.details?.url;
+    }
+
+    private raiseStarted(summary: WindowSummary) {
+        this.registry.execute("on-started", { summary });
+    }
+
+    private raiseLoaded(summary: WindowSummary) {
+        this.registry.execute("on-loaded", { summary });
+    }
+
+    private raiseFailed(component: GoldenLayout.Component, workspaceId: string) {
+        this.registry.execute("on-failed", { component, workspaceId });
+    }
+
+    private getTitleByAppName(appName: string): string {
+        if (!appName) {
+            return undefined;
+        }
+        return this._glue.appManager?.application(appName)?.title;
+    }
+
+    private getAppNameByWindowId(windowId: string): string {
+        return this._glue.appManager?.instances()?.find(i => i.id === windowId)?.application?.name;
+    }
+
+    private notifyFrameWillStart(windowId: string, appName?: string, context?: any, title?: string) {
+        return this._glue.interop.invoke(PlatformControlMethod, {
+            domain: appName ? "appManager" : "windows",
+            operation: appName ? "registerWorkspaceApp" : "registerWorkspaceWindow",
+            data: {
+                name: `${appName || "window"}_${windowId}`,
+                windowId,
+                frameId: this._manager.frameId,
+                appName,
+                context,
+                title
+            }
+        });
+    }
+
+    private waitFor(numberOfTriggers: number, callback: () => void): [(x: any) => void, () => void] {
+        let triggersActivated = [] as any[];
+
+        return [
+            (x: any) => {
+                triggersActivated.push(x);
+                if (triggersActivated.length === numberOfTriggers) {
+                    callback();
+                }
+            },
+            () => triggersActivated
+        ]
+    }
+
+    private vaidateTitle(title: string) {
+        if (!title?.length) {
+            return undefined;
+        }
+
+        return title;
+    }
+}

--- a/packages/workspaces-ui-core/src/interop/types.ts
+++ b/packages/workspaces-ui-core/src/interop/types.ts
@@ -132,6 +132,16 @@ export interface PingRequest {
     operationArguments: {}
 }
 
+export interface HibernateWorkspaceRequest {
+    operation: "hibernateWorkspace";
+    operationArguments: WorkspaceSelector;
+}
+
+export interface ResumeWorkspaceRequest {
+    operation: "resumeWorkspace";
+    operationArguments: WorkspaceSelector;
+}
+
 //#endregion
 
 //#region Arguments
@@ -255,6 +265,9 @@ export interface GenerateLayoutArguments {
     workspaceId: string;
     name: string;
 }
+export interface WorkspaceSelector {
+    workspaceId: string;
+}
 
 //#endregion
 
@@ -263,4 +276,4 @@ export type ControlArguments = SaveLayoutRequest | DeleteLayoutRequest |
     CloseItemRequest | MaximizeItemRequest | RestoreItemRequest | AddWindowRequest | AddContainerRequest | SetItemTitleRequest |
     AddWorkspaceChildrenRequest | EjectRequest | CreateWorkspaceRequest | ForceLoadWindowRequest | FocusItemRequest |
     BundleWorkspaceRequest | IsWindowInWorkspaceRequest | GetFrameSummaryRequest | MoveFrameRequest | GetFrameSnapshotRequest |
-    GetSnapshotRequest | MoveWindowToRequest | GenerateLayoutRequest | PingRequest;
+    GetSnapshotRequest | MoveWindowToRequest | GenerateLayoutRequest | PingRequest | HibernateWorkspaceRequest | ResumeWorkspaceRequest;

--- a/packages/workspaces-ui-core/src/manager.ts
+++ b/packages/workspaces-ui-core/src/manager.ts
@@ -23,8 +23,9 @@ import { PopupManager } from "./popups/external";
 import { ComponentPopupManager } from "./popups/component";
 import { generate } from "shortid";
 import { GlueFacade } from "./interop/facade";
+import { ApplicationFactory } from "./app/factory";
 
-class WorkspacesManager {
+export class WorkspacesManager {
     private _controller: LayoutController;
     private _frameController: IFrameController;
     private _frameId: string;
@@ -38,6 +39,7 @@ class WorkspacesManager {
     private _initialized: boolean;
     private _glue: Glue42Web.API;
     private _configFactory: WorkspacesConfigurationFactory;
+    private _applicationFactory: ApplicationFactory;
     private _facade: GlueFacade;
     private _isDisposing: boolean;
 
@@ -80,6 +82,7 @@ class WorkspacesManager {
         this._stateResolver = new LayoutStateResolver(this._frameId, eventEmitter);
         this._controller = new LayoutController(eventEmitter, this._stateResolver, startupConfig, this._configFactory);
         this._frameController = new IFrameController(glue);
+        this._applicationFactory = new ApplicationFactory(glue, this.stateResolver, this._frameController, this);
         this._layoutsManager = new LayoutsManager(this.stateResolver, glue, this._configFactory, converter);
         this._popupManager = new PopupManagerComposer(new PopupManager(glue), new ComponentPopupManager(componentFactory, frameId), componentFactory);
 
@@ -112,9 +115,10 @@ class WorkspacesManager {
             saveContext
         });
 
-        (workspace.layout.config.workspacesOptions as WorkspaceOptionsWithLayoutName).layoutName = name;
-        if (workspace.layout.config.workspacesOptions.noTabHeader) {
-            delete workspace.layout.config.workspacesOptions.noTabHeader;
+        const config = workspace.layout?.config || workspace.hibernateConfig;
+        (config.workspacesOptions as WorkspaceOptionsWithLayoutName).layoutName = name;
+        if (config.workspacesOptions.noTabHeader) {
+            delete config.workspacesOptions.noTabHeader;
         }
 
         return result;
@@ -201,6 +205,9 @@ class WorkspacesManager {
             store.workspaceIds.forEach((wid) => this.closeWorkspace(store.getById(wid)));
         } else if (win) {
             const windowContentItem = store.getWindowContentItem(itemId);
+            if (!windowContentItem) {
+                throw new Error(`Could not find item ${itemId} to close`);
+            }
             this.closeTab(windowContentItem);
         } else if (container) {
             this._controller.closeContainer(itemId);
@@ -246,7 +253,7 @@ class WorkspacesManager {
             return { windowId: ejectedInstance.id };
         }
 
-        const ejectedWindowUrl = this.getUrlByAppName(appName) || url;
+        const ejectedWindowUrl = this._applicationFactory.getUrlByAppName(appName) || url;
         const ejectedWindow = await this._glue.windows.open(`${appName}_${windowId}`, ejectedWindowUrl, { context, windowId } as Glue42Web.Windows.Settings);
 
         return { windowId: ejectedWindow.id };
@@ -285,6 +292,9 @@ class WorkspacesManager {
 
     public async loadWindow(itemId: string) {
         let contentItem = store.getWindowContentItem(itemId);
+        if (!contentItem) {
+            throw new Error(`Could not find window ${itemId} to load`);
+        }
         let { windowId } = contentItem.config.componentState;
         if (!windowId) {
             await this.waitForFrameLoaded(itemId);
@@ -325,8 +335,11 @@ class WorkspacesManager {
         const workspace = store.getById(itemId);
 
         if (this._frameId === itemId) {
-            await this._glue.windows.my().focus();
+            // do nothing
         } else if (workspace) {
+            if (workspace.hibernateConfig) {
+                await this.resumeWorkspace(workspace.id);
+            }
             this._controller.focusWorkspace(workspace.id);
         } else {
             this._controller.focusWindow(itemId);
@@ -334,6 +347,9 @@ class WorkspacesManager {
     }
 
     public bundleWorkspace(workspaceId: string, type: "row" | "column") {
+        if (this._stateResolver.isWorkspaceHibernated(workspaceId)) {
+            throw new Error(`Could not bundle workspace ${workspaceId} because its hibernated`);
+        }
         this._controller.bundleWorkspace(workspaceId, type);
     }
 
@@ -355,6 +371,10 @@ class WorkspacesManager {
             throw new Error(`Could not find container ${containerId} in frame ${this._frameId}`);
         }
 
+        if (this._stateResolver.isWorkspaceHibernated(targetWorkspace.id)) {
+            throw new Error(`Could not move window ${itemId} to workspace ${targetWorkspace.id} because its hibernated`);
+        }
+
         const targetWindow = store.getWindowContentItem(itemId);
         if (!targetWindow) {
             throw new Error(`Could not find window ${itemId} in frame ${this._frameId}`);
@@ -370,6 +390,84 @@ class WorkspacesManager {
         }
 
         return this._layoutsManager.generateLayout(name, workspace);
+    }
+
+    public async resumeWorkspace(workspaceId: string) {
+        const workspace = store.getById(workspaceId);
+        if (!workspace) {
+            throw new Error(`Could not find workspace ${workspaceId} in any of the frames`);
+        }
+
+        const hibernatedConfig = workspace.hibernateConfig;
+
+        if (!hibernatedConfig.workspacesOptions) {
+            hibernatedConfig.workspacesOptions = {};
+        }
+
+        hibernatedConfig.workspacesOptions.reuseWorkspaceId = workspaceId;
+
+        // the start mode should always be eager
+        await this.createWorkspace(hibernatedConfig);
+
+        workspace.hibernateConfig = undefined;
+        this._controller.showSaveIcon(workspaceId);
+    }
+
+    public async hibernateWorkspace(workspaceId: string) {
+        const workspace = store.getById(workspaceId);
+
+        if (store.getActiveWorkspace().id === workspace.id) {
+            throw new Error(`Cannot hibernate workspace ${workspace.id} because its active`);
+        }
+
+        if (this.stateResolver.isWorkspaceHibernated(workspaceId)) {
+            throw new Error(`Cannot hibernate workspace ${workspaceId} because it has already been hibernated`);
+        }
+
+        if (!workspace.layout) {
+            throw new Error(`Cannot hibernate workspace ${workspace.id} because its empty`);
+        }
+
+        const snapshot = await this.stateResolver.getWorkspaceConfig(workspace.id);
+
+        workspace.hibernatedWindows = workspace.windows;
+        (snapshot.workspacesOptions as any).isHibernated = true;
+        workspace.hibernateConfig = snapshot;
+
+        workspace.windows.map((w) => store.getWindowContentItem(w.id)).forEach((w) => this.closeTab(w, false));
+
+        store.removeLayout(workspace.id);
+
+        this._controller.showHibernationIcon(workspaceId);
+
+        return snapshot;
+    }
+
+    public closeTab(item: GoldenLayout.ContentItem, emptyWorkspaceCheck: boolean = true) {
+        const itemId = idAsString(item.config.id);
+        const workspace = store.getByWindowId(itemId);
+        const windowSummary = this.stateResolver.getWindowSummarySync(itemId);
+
+        this._controller.removeLayoutElement(itemId);
+        this._frameController.remove(itemId);
+
+        this._applicationFactory.notifyFrameWillClose(windowSummary.config.windowId, windowSummary.config.appName).catch((e) => {
+            // Log the error
+        });
+
+        if (!workspace.hibernatedWindows.some((hw) => windowSummary.itemId === hw.id)) {
+            this.workspacesEventEmitter.raiseWindowEvent({
+                action: "removed",
+                payload: {
+                    windowSummary
+                }
+            });
+        }
+
+
+        if (!workspace.windows.length && emptyWorkspaceCheck) {
+            this.checkForEmptyWorkspace(workspace);
+        }
     }
 
     public unmount() {
@@ -415,124 +513,7 @@ class WorkspacesManager {
 
     private subscribeForLayout() {
         this._controller.emitter.onContentComponentCreated(async (component, workspaceId) => {
-            if (component.config.componentName === EmptyVisibleWindowName) {
-                return;
-            }
-            const workspace = store.getById(workspaceId);
-            const newWindowBounds = getElementBounds(component.element);
-            const { componentState } = component.config;
-            const { title, appName } = componentState;
-            let { windowId } = componentState;
-            const componentId = idAsString(component.config.id);
-            const applicationTitle = this.getTitleByAppName(appName);
-            const windowTitle = this.vaidateTitle(title) || this.vaidateTitle(applicationTitle) || this.vaidateTitle(appName) || "Glue";
-            const windowContext = component?.config.componentState?.context;
-            let url = this.getUrlByAppName(componentState.appName) || componentState.url;
-
-            const isNewWindow = !store.getWindow(componentId);
-
-            store.addWindow({
-                id: componentId,
-                bounds: newWindowBounds,
-                windowId,
-                url,
-                appName
-            }, workspace.id);
-
-            if (!url && windowId) {
-                const win = this._glue.windows.list().find((w) => w.id === windowId);
-
-                url = await win.getURL();
-                const newlyAddedWindow = store.getWindow(componentId) as WorkspacesWindow;
-
-                newlyAddedWindow.url = url;
-            }
-
-            windowId = windowId || generate();
-
-            if (component.config.componentState?.context) {
-                delete component.config.componentState.context;
-            }
-
-            component.config.componentState.url = url;
-            if (windowTitle) {
-                component.setTitle(windowTitle);
-            }
-            if (isNewWindow) {
-                const windowSummary = this.stateResolver.getWindowSummarySync(componentId, component);
-                this.workspacesEventEmitter.raiseWindowEvent({
-                    action: "added",
-                    payload: {
-                        windowSummary
-                    }
-                });
-
-                const glueWinOutsideOfWorkspace = this._glue.windows.findById(windowId);
-                if (glueWinOutsideOfWorkspace) {
-                    try {
-                        // Glue windows with the given id should be closed
-                        await glueWinOutsideOfWorkspace.close();
-                    } catch (error) {
-                        // because of chrome security policy this call can fail,
-                        // however the opening of a new window should continue
-                    }
-                }
-            }
-
-            try {
-                await this.notifyFrameWillStart(windowId, appName, windowContext, windowTitle);
-                await this._frameController.startFrame(componentId, url, undefined, windowId);
-                const newlyAddedWindow = store.getWindow(componentId) as WorkspacesWindow;
-
-                component.config.componentState.windowId = windowId;
-                newlyAddedWindow.windowId = windowId;
-
-                const newlyOpenedWindow = this._glue.windows.findById(windowId);
-                newlyOpenedWindow.getTitle().then((winTitle) => {
-                    if (this.vaidateTitle(windowTitle)) {
-                        component.setTitle(winTitle);
-                    }
-                }).catch((e) => {
-                    console.warn("Failed while setting the window title", e);
-                });
-
-                this._frameController.moveFrame(componentId, getElementBounds(component.element));
-
-                if (isNewWindow) {
-                    this._workspacesEventEmitter.raiseWindowEvent({
-                        action: "loaded",
-                        payload: {
-                            windowSummary: await this.stateResolver.getWindowSummary(componentId)
-                        }
-                    });
-                }
-
-                if (!appName) {
-                    const appNameToUse = this.getAppNameByWindowId(windowId);
-                    if (!component.config.componentState) {
-                        throw new Error(`Invalid state - the created component ${componentId} with windowId ${windowId} is missing its state object`);
-                    }
-                    component.config.componentState.appName = appNameToUse;
-
-
-                    newlyAddedWindow.appName = appNameToUse;
-                }
-
-            } catch (error) {
-                // If a frame doesn't initialize properly remove its windowId
-                component.config.componentState.windowId = undefined;
-                if (url) {
-                    this._frameController.moveFrame(componentId, getElementBounds(component.element));
-                } else {
-                    this.closeTab(component, false);
-                }
-                const wsp = store.getById(workspaceId);
-                if (!wsp) {
-                    throw new Error(`Workspace ${workspaceId} failed ot initialize because none of the specified windows were able to load
-                    Internal error: ${error}`);
-                }
-            }
-
+            await this._applicationFactory.start(component, workspaceId);
         });
 
         this._controller.emitter.onContentItemResized((target, id) => {
@@ -639,6 +620,7 @@ class WorkspacesManager {
 
         this._controller.emitter.onWorkspaceSelectionChanged((workspace, toBack) => {
             this._popupManager.hidePopup();
+
             if (!workspace.layout) {
                 this._frameController.selectionChangedDeep([], toBack.map((w) => w.id));
                 this._workspacesEventEmitter.raiseWorkspaceEvent({
@@ -647,6 +629,10 @@ class WorkspacesManager {
                         workspaceSummary: this.stateResolver.getWorkspaceSummary(workspace.id)
                     }
                 });
+
+                if (workspace.hibernateConfig) {
+                    this.resumeWorkspace(workspace.id);
+                }
                 return;
             }
             const allWinsInLayout = getAllWindowsFromConfig(workspace.layout.toConfig().content)
@@ -659,6 +645,8 @@ class WorkspacesManager {
                     workspaceSummary: this.stateResolver.getWorkspaceSummary(workspace.id)
                 }
             });
+
+
         });
 
         this._controller.emitter.onAddButtonClicked(async ({ laneId, workspaceId, bounds, parentType }) => {
@@ -776,6 +764,16 @@ class WorkspacesManager {
             this._frameController.selectionChangedDeep([], workspace.windows.map(w => w.id));
         });
 
+        this.workspacesEventEmitter.onWorkspaceEvent((action, payload) => {
+            const workspace = store.getById(payload.workspaceSummary.id);
+
+            if (!workspace) {
+                return;
+            }
+
+            workspace.lastActive = Date.now();
+        });
+
         // debouncing because there is potential for 1ms spam
         let resizedTimeout: NodeJS.Timeout = undefined;
         componentStateMonitor.onWorkspaceContentsResized((workspaceId: string) => {
@@ -816,12 +814,15 @@ class WorkspacesManager {
         const workspaceSummaries = store.workspaceIds.map((wid) => {
             const workspace = store.getById(wid);
             windowSummaries.push(...workspace.windows.map(w => this.stateResolver.getWindowSummarySync(w.id)));
+            const snapshot = this.stateResolver.getWorkspaceConfig(wid);
+            const hibernatedSummaries = this.stateResolver.extractWindowSummariesFromSnapshot(snapshot);
+            windowSummaries.push(...hibernatedSummaries);
 
             return this.stateResolver.getWorkspaceSummary(wid);
         });
 
         windowSummaries.forEach((ws) => {
-            this.notifyFrameWillClose(ws.config.windowId, ws.config.appName).catch((e) => {
+            this._applicationFactory.notifyFrameWillClose(ws.config.windowId, ws.config.appName).catch((e) => {
                 // Log the error
             });
             this.workspacesEventEmitter.raiseWindowEvent({ action: "removed", payload: { windowSummary: ws } });
@@ -849,36 +850,19 @@ class WorkspacesManager {
         });
     }
 
-    private closeTab(item: GoldenLayout.ContentItem, emptyWorkspaceCheck: boolean = true) {
-        const itemId = idAsString(item.config.id);
-        const workspace = store.getByWindowId(itemId);
-        const windowSummary = this.stateResolver.getWindowSummarySync(itemId);
-
-        this._controller.removeLayoutElement(itemId);
-        this._frameController.remove(itemId);
-
-        this.notifyFrameWillClose(windowSummary.config.windowId, windowSummary.config.appName).catch((e) => {
-            // Log the error
-        });
-
-        this.workspacesEventEmitter.raiseWindowEvent({
-            action: "removed",
-            payload: {
-                windowSummary
-            }
-        });
-
-
-        if (!workspace.windows.length && emptyWorkspaceCheck) {
-            this.checkForEmptyWorkspace(workspace);
-        }
-    }
-
     private closeWorkspace(workspace: Workspace) {
         if (!workspace) {
             throw new Error("Could not find a workspace to close");
         }
 
+        if (workspace.hibernateConfig) {
+            this.closeHibernatedWorkspaceCore(workspace);
+        } else {
+            this.closeWorkspaceCore(workspace);
+        }
+    }
+
+    private async closeWorkspaceCore(workspace: Workspace) {
         const workspaceSummary = this.stateResolver.getWorkspaceSummary(workspace.id);
         const windowSummaries = workspace.windows.map((w) => {
             if (store.getWindowContentItem(w.id)) {
@@ -887,9 +871,41 @@ class WorkspacesManager {
         }).filter(ws => ws);
 
         workspace.windows.forEach((w) => this._frameController.remove(w.id));
+
         const isFrameEmpty = this.checkForEmptyWorkspace(workspace);
         windowSummaries.forEach((ws) => {
-            this.notifyFrameWillClose(ws.config.windowId, ws.config.appName).catch((e) => {
+            this._applicationFactory.notifyFrameWillClose(ws.config.windowId, ws.config.appName).catch((e) => {
+                // Log the error
+            });
+            this.workspacesEventEmitter.raiseWindowEvent({
+                action: "removed",
+                payload: {
+                    windowSummary: ws
+                }
+            });
+        });
+        if (isFrameEmpty) {
+            return;
+        }
+        this.workspacesEventEmitter.raiseWorkspaceEvent({
+            action: "closed",
+            payload: {
+                workspaceSummary,
+                frameSummary: { id: this._frameId }
+            }
+        });
+    }
+
+    private async closeHibernatedWorkspaceCore(workspace: Workspace) {
+        const workspaceSummary = this.stateResolver.getWorkspaceSummary(workspace.id);
+        const snapshot = this.stateResolver.getSnapshot(workspace.id) as GoldenLayout.Config;
+        const windowSummaries = this.stateResolver.extractWindowSummariesFromSnapshot(snapshot);
+
+        workspace.windows.forEach((w) => this._frameController.remove(w.id));
+
+        const isFrameEmpty = this.checkForEmptyWorkspace(workspace);
+        windowSummaries.forEach((ws) => {
+            this._applicationFactory.notifyFrameWillClose(ws.config.windowId, ws.config.appName).catch((e) => {
                 // Log the error
             });
             this.workspacesEventEmitter.raiseWindowEvent({
@@ -968,55 +984,13 @@ class WorkspacesManager {
         });
     }
 
-    private getUrlByAppName(appName: string): string {
-        if (!appName) {
-            return undefined;
-        }
-        return this._glue.appManager?.application(appName)?.userProperties?.details?.url;
-    }
-
-    private getTitleByAppName(appName: string): string {
-        if (!appName) {
-            return undefined;
-        }
-        return this._glue.appManager?.application(appName)?.title;
-    }
-
-    private getAppNameByWindowId(windowId: string): string {
-        return this._glue.appManager?.instances()?.find(i => i.id === windowId)?.application?.name;
-    }
-
-    private notifyFrameWillStart(windowId: string, appName?: string, context?: any, title?: string) {
-        return this._glue.interop.invoke(PlatformControlMethod, {
-            domain: appName ? "appManager" : "windows",
-            operation: appName ? "registerWorkspaceApp" : "registerWorkspaceWindow",
-            data: {
-                name: `${appName || "window"}_${windowId}`,
-                windowId,
-                frameId: this.frameId,
-                appName,
-                context,
-                title
+    private raiseWindowRemoved(workspaceId: string, windowSummary: WindowSummary) {
+        this.workspacesEventEmitter.raiseWindowEvent({
+            action: "removed",
+            payload: {
+                windowSummary
             }
-        });
-    }
-
-    private notifyFrameWillClose(windowId: string, appName?: string) {
-        return this._glue.interop.invoke(PlatformControlMethod, {
-            domain: appName ? "appManager" : "windows",
-            operation: appName ? "unregisterWorkspaceApp" : "unregisterWorkspaceWindow",
-            data: {
-                windowId,
-            }
-        });
-    }
-
-    private vaidateTitle(title: string) {
-        if (!title?.length) {
-            return undefined;
-        }
-
-        return title;
+        })
     }
 }
 

--- a/packages/workspaces-ui-core/src/store.ts
+++ b/packages/workspaces-ui-core/src/store.ts
@@ -68,7 +68,9 @@ class WorkspaceStore {
         this._idToLayout[id] = {
             id,
             windows,
-            layout
+            layout,
+            hibernatedWindows: [],
+            lastActive: Date.now()
         };
     }
 

--- a/packages/workspaces-ui-core/src/types/internal.ts
+++ b/packages/workspaces-ui-core/src/types/internal.ts
@@ -74,6 +74,9 @@ export interface WorkspaceConfig {
     positionIndex: number;
     name: string;
     layoutName?: string;
+    isHibernated: boolean;
+    isSelected: boolean;
+    lastActive: number;
 }
 
 export interface WindowSummary {
@@ -140,8 +143,11 @@ export interface Window {
 export interface Workspace {
     id: string;
     windows: Window[];
+    hibernatedWindows: Window[];
     layout: GoldenLayout;
+    hibernateConfig?: GoldenLayout.Config;
     context?: object;
+    lastActive: number;
 }
 
 export interface WorkspaceLayout {


### PR DESCRIPTION
## Hibernate/Resume functionality

Workspaces can now be configured to ```hibernate``` in certain situations which are controlled by rules. The rules can be usage based - when a workspace has not been focused in X minutes it should be hibernated or quantity based -  when there are more opened and active (a hibernated or an empty workspace are not counted, because no performance optimization can be achieved from their hibernation) workspaces than the given threshold are currently active the last one to be selected will be hibernated. The rules are being checked in specified interval provided in the platform config object.

The state of hibernation means that all of the workspace windows are closed, however the layout is being preserved so when focused or resumed programmatically the previous state will be restored. In this state the workspace can't accept API operations which will make modifications.