### PR TITLE
reconfigure js tutorial server to prevent caching

### DIFF
--- a/tutorials/javascript/start/package.json
+++ b/tutorials/javascript/start/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "description": "Glue42 Core JavaScript Tutorial",
   "scripts": {
-    "start:clients": "http-server ./Clients -p 9000",
-    "start:stocks": "http-server ./Stocks -p 9100",
-    "start:clientDetails": "http-server ./client-details -p 9200",
-    "start:workspace": "http-server ./workspace -p 9300",
+    "start:clients": "http-server ./Clients -p 9000 -c-1",
+    "start:stocks": "http-server ./Stocks -p 9100 -c-1",
+    "start:clientDetails": "http-server ./client-details -p 9200 -c-1",
+    "start:workspace": "http-server ./workspace -p 9300 -c-1",
     "start": "concurrently \"npm run start:clients\" \"npm run start:stocks\" \"npm run start:clientDetails\" \"npm run start:workspace\""
   },
   "keywords": [],


### PR DESCRIPTION
Going through the JS tutorial I found it frustrating when I would make changes to an html or javascript file, only to have the changes fail to appear in the browser because the browser was caching the documents. This PR uses an http-server configuration option to prevent caching of files. As a result, after making changes to an html or javascript file you only need to refresh the browser and the changes will automatically appear.

see cache-control headers:

![image](https://user-images.githubusercontent.com/18009315/117877671-d5ec9680-b272-11eb-8ae0-20b25b1410bf.png)
