### PR TITLE
docs: update creation of channel selector widget

### DIFF
--- a/tutorials/guides/02_core/01_javascript/javascript.md
+++ b/tutorials/guides/02_core/01_javascript/javascript.md
@@ -602,7 +602,7 @@ Finally, pass these arguments to `createChannelSelectorWidget()`:
 ```javascript
 // In `start()`.
 
-await createChannelSelectorWidget(
+createChannelSelectorWidget(
     NO_CHANNEL_VALUE,
     channelNamesAndColors,
     onChannelSelected


### PR DESCRIPTION
* `createChannelSelectorWidget` returns a function, not a promise,
  so there's no need to to `await createChannelSelectorWidget(..)`
  in the tutorial.