### PR TITLE
Implement Advanced Notifications

### DIFF
--- a/e2e/config.js
+++ b/e2e/config.js
@@ -16,6 +16,9 @@ module.exports = {
     ],
     run: [
         {
+            groupName: 'notifications'
+        },
+        {
             groupName: 'system'
         },
         {

--- a/e2e/tests/notifications/raise.spec.js
+++ b/e2e/tests/notifications/raise.spec.js
@@ -1,0 +1,278 @@
+describe("raise ", () => {
+
+    before(() => coreReady);
+    afterEach(() => {
+        window.sinonSandbox.reset();
+        window.notificationsFakeTriggerClick = false;
+        if (glue.interop.methods().some((method) => method.name === "testMethod")) {
+            return glue.interop.unregister("testMethod");
+        }
+    });
+
+    it("should resolve", async () => {
+        await glue.notifications.raise({ title: "test" });
+    });
+
+    [
+        { title: "asd" },
+        { title: "asd", badge: "http://test.com" },
+        { title: "asd", body: "test description" },
+        { title: "asd", data: { test: 42 } },
+        { title: "asd", dir: "auto" },
+        { title: "asd", icon: "http://test.com" },
+        { title: "asd", image: "http://test.com" },
+        { title: "asd", lang: "EN" },
+        { title: "asd", renotify: true },
+        { title: "asd", requireInteraction: true },
+        { title: "asd", silent: true },
+        { title: "asd", tag: "test42" },
+        { title: "asd", timestamp: 1209837 },
+        { title: "asd", vibrate: [200, 200, 100] }
+    ].forEach((input) => {
+        it(`should raise native notification with correct options and title: ${JSON.stringify(input)}`, async () => {
+
+            await glue.notifications.raise(input);
+
+            const title = window.notificationConstructorFake.firstArg;
+            const settings = window.notificationConstructorFake.lastArg;
+
+
+            Object.keys(input).forEach((key) => {
+                if (key === "title") {
+                    expect(input[key]).to.eql(title);
+                    return;
+                }
+
+                expect(input[key]).to.eql(settings[key]);
+            })
+        });
+    });
+
+    [
+        { title: "asd", actions: [{ action: "one", title: "one", icon: "http://one.com" }] },
+        { title: "asd", actions: [{ action: "one", title: "one", icon: "http://one.com" }], badge: "http://test.com" },
+        { title: "asd", actions: [{ action: "one", title: "one", icon: "http://one.com" }], body: "test description" },
+        { title: "asd", actions: [{ action: "one", title: "one", icon: "http://one.com" }], data: { test: 42 } },
+        { title: "asd", actions: [{ action: "one", title: "one", icon: "http://one.com" }], dir: "auto" },
+        { title: "asd", actions: [{ action: "one", title: "one", icon: "http://one.com" }], icon: "http://test.com" },
+        { title: "asd", actions: [{ action: "one", title: "one", icon: "http://one.com" }], image: "http://test.com" },
+        { title: "asd", actions: [{ action: "one", title: "one", icon: "http://one.com" }], lang: "EN" },
+        { title: "asd", actions: [{ action: "one", title: "one", icon: "http://one.com" }], renotify: true },
+        { title: "asd", actions: [{ action: "one", title: "one", icon: "http://one.com" }], requireInteraction: true },
+        { title: "asd", actions: [{ action: "one", title: "one", icon: "http://one.com" }], silent: true },
+        { title: "asd", actions: [{ action: "one", title: "one", icon: "http://one.com" }], tag: "test42" },
+        { title: "asd", actions: [{ action: "one", title: "one", icon: "http://one.com" }], timestamp: 1209837 },
+        { title: "asd", actions: [{ action: "one", title: "one", icon: "http://one.com" }], vibrate: [200, 200, 100] }
+    ].forEach((input) => {
+        it(`should raise service worker notification with correct options and title: ${JSON.stringify(input)}`, async () => {
+
+            await glue.notifications.raise(input);
+
+            const title = window.showNotificationFake.firstArg;
+            const settings = window.showNotificationFake.lastArg;
+
+            Object.keys(input).forEach((key) => {
+                if (key === "title") {
+                    expect(input[key]).to.eql(title);
+                    return;
+                }
+
+                if (key === "data") {
+                    Object.keys(input.data).forEach((dataKey) => {
+                        expect(input.data[dataKey]).to.eql(settings.data[dataKey]);
+                    });
+                    return;
+                }
+
+                expect(input[key]).to.eql(settings[key]);
+            })
+        });
+    });
+
+    it("should invoke the onshow handler for native notifications", (done) => {
+        glue.notifications.raise({ title: "test" })
+            .then((notification) => {
+                notification.onshow = () => done();
+            })
+            .catch(done);
+    });
+
+    it("should invoke the onshow handler for service worker notifications", (done) => {
+        glue.notifications.raise({ title: "test", actions: [{ action: "one", title: "one", icon: "http://one.com" }] })
+            .then((notification) => {
+                notification.onshow = () => done();
+            })
+            .catch(done);
+    });
+
+    it("should invoke the onclick handler for native notifications", (done) => {
+        window.notificationsFakeTriggerClick = true;
+
+        glue.notifications.raise({ title: "test" })
+            .then((notification) => {
+
+                notification.onclick = () => done();
+            })
+            .catch(done);
+    });
+
+    it("should not invoke the onclick handler for native notifications when the notification has not been clicked on", (done) => {
+        setTimeout(done, 1500);
+
+        glue.notifications.raise({ title: "test" })
+            .then((notification) => {
+
+                notification.onclick = () => done();
+            })
+            .catch(done);
+    });
+
+    it("should invoke the onclick handler for service worker notifications", (done) => {
+        const definition = { actions: [{ action: "one", title: "one", icon: "http://one.com" }] };
+
+        glue.notifications.raise(Object.assign({}, definition, { title: "test" }))
+            .then((notification) => {
+                notification.onclick = () => done();
+
+                const settings = window.showNotificationFake.lastArg;
+
+                const channel = new BroadcastChannel("glue42-core-worker");
+                channel.postMessage({ messageType: "notificationClick", glueData: settings.data.glueData, definition });
+
+            })
+            .catch(done);
+    });
+
+    it("should not invoke the onclick handler for service worker notifications when the notification has not been clicked on", (done) => {
+        setTimeout(done, 1500);
+
+        const definition = { actions: [{ action: "one", title: "one", icon: "http://one.com" }] };
+
+        glue.notifications.raise(Object.assign({}, definition, { title: "test" }))
+            .then((notification) => {
+                notification.onclick = () => done();
+            })
+            .catch(done);
+    });
+
+    it("should invoke a defined method when clickInterop is configured", (done) => {
+        const ready = gtf.waitFor(2, done);
+
+        window.notificationsFakeTriggerClick = true;
+
+        glue.interop.register("testMethod", () => ready())
+            .then(() => {
+                return glue.notifications.raise({ title: "test", clickInterop: { method: "testMethod" } })
+            })
+            .then(ready)
+            .catch(done);
+
+    });
+
+    it("should invoke a defined method with provided args when clickInterop is configured", (done) => {
+        const ready = gtf.waitFor(2, done);
+
+        const originalArgs = { test: 42 };
+
+        window.notificationsFakeTriggerClick = true;
+
+        glue.interop.register("testMethod", (args) => {
+            try {
+                expect(args).to.eql(originalArgs);
+                ready()
+            } catch (error) {
+                done(error);
+            }
+        })
+            .then(() => {
+                return glue.notifications.raise({ title: "test", clickInterop: { method: "testMethod", arguments: originalArgs } })
+            })
+            .then(ready)
+            .catch(done);
+    });
+
+    it("should invoke a defined method when an action is clicked and defined", (done) => {
+
+        const ready = gtf.waitFor(2, done);
+
+        const definition = { actions: [{ action: "one", title: "one", icon: "http://one.com", interop: { method: "testMethod" } }] };
+
+        glue.interop.register("testMethod", () => ready())
+            .then(() => {
+                return glue.notifications.raise(Object.assign({}, definition, { title: "test" }))
+            })
+            .then(() => {
+                const settings = window.showNotificationFake.lastArg;
+
+                const channel = new BroadcastChannel("glue42-core-worker");
+                channel.postMessage({ action: definition.actions[0].action, messageType: "notificationClick", glueData: settings.data.glueData, definition });
+
+            })
+            .then(ready)
+            .catch(done);
+    });
+
+    it("should invoke a defined method with provided args when an action is clicked and defined", (done) => {
+        const ready = gtf.waitFor(2, done);
+
+        const originalArgs = { test: 42 };
+
+        const definition = { actions: [{ action: "one", title: "one", icon: "http://one.com", interop: { method: "testMethod", arguments: originalArgs } }] };
+
+        glue.interop.register("testMethod", (args) => {
+            try {
+                expect(args).to.eql(originalArgs);
+                ready()
+            } catch (error) {
+                done(error);
+            }
+        })
+            .then(() => {
+                return glue.notifications.raise(Object.assign({}, definition, { title: "test" }))
+            })
+            .then(() => {
+                const settings = window.showNotificationFake.lastArg;
+
+                const channel = new BroadcastChannel("glue42-core-worker");
+                channel.postMessage({ action: definition.actions[0].action, messageType: "notificationClick", glueData: settings.data.glueData, definition });
+
+            })
+            .then(ready)
+            .catch(done);
+    });
+
+    it("should reject when no title is provided", (done) => {
+        glue.notifications.raise()
+            .then(() => done("Should not have resolved, because no title was provided"))
+            .catch(() => done());
+    });
+
+    [
+        42,
+        "42",
+        true,
+        ["yes"],
+        { title: "asd", badge: true },
+        { title: "asd", body: 42 },
+        { title: "asd", dir: "please" },
+        { title: "asd", icon: ["http://test.com"] },
+        { title: "asd", image: { url: "http://test.com" } },
+        { title: "asd", lang: true },
+        { title: "asd", renotify: "true" },
+        { title: "asd", requireInteraction: [true] },
+        { title: "asd", silent: { value: true } },
+        { title: "asd", tag: 42 },
+        { title: "asd", timestamp: "2020" },
+        { title: "asd", vibrate: "200, 200, 100" },
+        { title: "asd", actions: [{ title: "one", icon: "http://one.com" }] },
+        { title: "asd", actions: [{ action: "one", icon: "http://one.com" }] },
+        { title: "asd", actions: [{ action: true, title: true, icon: "http://one.com" }] }
+    ].forEach((input) => {
+        it("should reject when the options are not valid", (done) => {
+            glue.notifications.raise(input)
+                .then(() => done(`Should not have resolved, because the input is not valid: ${JSON.stringify(input)}`))
+                .catch(() => done());
+        });
+    });
+
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "glue42core",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13931,6 +13931,41 @@
         "picomatch": "^2.2.2"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
+      "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -14037,6 +14072,15 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
       "dev": true
+    },
+    "@types/sinon": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.1.tgz",
+      "integrity": "sha512-tZulsvuJwif5ddTBtscflI7gJcd+RpENcNZ7QCp0jKEl0bZY3Pu6PbJs4GR3SfQkGgsUa+FrlKsKQ0XyGNvDuA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/fake-timers": "^7.1.0"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.26.0",
@@ -20970,6 +21014,12 @@
       "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "karma": {
       "version": "6.3.2",
       "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.2.tgz",
@@ -23154,6 +23204,12 @@
       "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -24645,6 +24701,36 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
+      "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^7.0.4",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-addon-api": {
       "version": "1.7.2",
@@ -27787,6 +27873,43 @@
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
           "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
           "dev": true
+        }
+      }
+    },
+    "sinon": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
+      "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^7.1.0",
+        "@sinonjs/samsam": "^6.0.2",
+        "diff": "^5.0.0",
+        "nise": "^5.1.0",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@lerna/changed": "^3.20.0",
     "@lerna/run": "^3.20.0",
+    "@types/sinon": "^10.0.1",
     "@typescript-eslint/eslint-plugin": "^2.25.0",
     "@typescript-eslint/parser": "^2.25.0",
     "body-parser": "^1.19.0",
@@ -49,6 +50,7 @@
     "rimraf": "^3.0.2",
     "rollup-plugin-typescript2": "^0.27.2",
     "simple-git": "^1.131.0",
+    "sinon": "^11.1.1",
     "tree-kill": "^1.2.2",
     "typescript": "^3.8.3"
   },

--- a/packages/web-platform/changelog.md
+++ b/packages/web-platform/changelog.md
@@ -1,4 +1,6 @@
-1.5.1
+1.6.0
+feat: added support for a Service Worker
+feat: added support for advanced notifications
 fix: fixed allowDropLeft, allowDropTop, allowDropRight, allowDropBottom in the workspaces config object by adding them to the decoders
 1.5.0
 feat: extended workspaces protocol and decoders for servicing frame bounds requests

--- a/packages/web-platform/platform.d.ts
+++ b/packages/web-platform/platform.d.ts
@@ -193,6 +193,13 @@ export namespace Glue42WebPlatform {
         }
     }
 
+    export namespace ServiceWorker {
+        export interface Config {
+            url?: string;
+            registrationPromise?: Promise<ServiceWorkerRegistration>;
+        }
+    }
+
     export namespace Plugins {
 
         export interface ControlMessage {
@@ -201,7 +208,7 @@ export namespace Glue42WebPlatform {
             data: any;
             commandId?: string;
         }
-        
+
         export interface PlatformControls {
             control: (args: ControlMessage) => Promise<any>;
             logger?: Glue42Web.Logger.API;
@@ -275,7 +282,7 @@ export namespace Glue42WebPlatform {
                  * Valid only in `delayed` mode. Number of applications in a batch to be loaded at each interval. Defaults to 1.
                  */
                 batch?: number;
-            }
+            };
             /**
              * Visual indicator `Zzz` on tabs of apps which are not loaded yet. Useful for developing and testing purposes.
              */
@@ -305,6 +312,7 @@ export namespace Glue42WebPlatform {
         layouts?: Layouts.Config;
         channels?: Channels.Config;
         plugins?: Plugins.Config;
+        serviceWorker?: ServiceWorker.Config;
         gateway?: Gateway.Config;
         glue?: Glue42Web.Config;
         workspaces?: Workspaces.Config;

--- a/packages/web-platform/src/common/constants.ts
+++ b/packages/web-platform/src/common/constants.ts
@@ -25,4 +25,6 @@ export const ChannelContextPrefix = "___channel___";
 
 export const dbName = "glue42core";
 
+export const serviceWorkerBroadcastChannelName = "glue42-core-worker";
+
 export const dbVersion = 1;

--- a/packages/web-platform/src/common/types.ts
+++ b/packages/web-platform/src/common/types.ts
@@ -6,7 +6,7 @@ import { Glue42WebPlatform } from "../../platform";
 
 export type Glue42API = Glue42.Glue;
 export type Glue42Config = Glue42.Config;
-export type LibDomains = "system" | "windows" | "appManager" | "layouts" | "workspaces" | "intents" | "channels";
+export type LibDomains = "system" | "windows" | "appManager" | "layouts" | "workspaces" | "intents" | "channels" | "notifications";
 
 export interface InternalWindowsConfig {
     windowResponseTimeoutMs: number;
@@ -36,6 +36,7 @@ export interface InternalPlatformConfig {
     plugins?: {
         definitions: Glue42WebPlatform.Plugins.PluginDefinition[];
     };
+    serviceWorker?: Glue42WebPlatform.ServiceWorker.Config;
     workspaces?: Glue42WebPlatform.Workspaces.Config;
     environment: any;
 }

--- a/packages/web-platform/src/controllers/serviceWorker.ts
+++ b/packages/web-platform/src/controllers/serviceWorker.ts
@@ -1,0 +1,160 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Glue42Web } from "@glue42/web";
+import { serviceWorkerBroadcastChannelName } from "../common/constants";
+import { InternalPlatformConfig } from "../common/types";
+import logger from "../shared/logger";
+import {
+    default as CallbackRegistryFactory,
+    CallbackRegistry,
+    UnsubscribeFunction,
+} from "callback-registry";
+import { GlueNotificationData } from "../libs/notifications/types";
+
+export class ServiceWorkerController {
+    private readonly registry: CallbackRegistry = CallbackRegistryFactory();
+    private _serviceWorkerRegistration: ServiceWorkerRegistration | undefined;
+    private channel!: BroadcastChannel;
+
+    private get logger(): Glue42Web.Logger.API | undefined {
+        return logger.get("service.worker.web.platform");
+    }
+
+    private get serviceWorkerRegistration(): ServiceWorkerRegistration {
+        if (!this._serviceWorkerRegistration) {
+            throw new Error("Accessing missing service worker registration object. This is caused because the application is trying to raise a persistent notification, which requires a service worker. Please provide a service worker config when initializing GlueWebPlatform.");
+        }
+
+        return this._serviceWorkerRegistration;
+    }
+
+    public async connect(config: InternalPlatformConfig): Promise<void> {
+        if (!config.serviceWorker) {
+            return;
+        }
+
+        this.logger?.info("Detected service worker definition, connecting...");
+
+        if (!config.serviceWorker.url && !config.serviceWorker.registrationPromise) {
+            throw new Error("The service worker config is defined, but it is missing a url or a registration promise, please provide one or the other");
+        }
+
+        if (config.serviceWorker.url && config.serviceWorker.registrationPromise) {
+            throw new Error("The service worker is over-specified, there is both defined url and a registration promise, please provide one or the other");
+        }
+
+        this._serviceWorkerRegistration = config.serviceWorker.url ?
+            await this.registerWorker(config.serviceWorker.url) :
+            await this.waitRegistration(config.serviceWorker.registrationPromise as Promise<ServiceWorkerRegistration>);
+
+        if (this._serviceWorkerRegistration) {
+            this.setUpBroadcastChannelConnection();
+        }
+
+        this.logger?.info("Service worker connection completed.");
+    }
+
+    public async showNotification(settings: Glue42Web.Notifications.RaiseOptions, id: string): Promise<void> {
+
+        const options: NotificationOptions = Object.assign({}, settings, { title: undefined, clickInterop: undefined, actions: undefined });
+
+        options.actions = settings.actions?.map((action) => {
+            return {
+                action: action.action,
+                title: action.title,
+                icon: action.icon
+            };
+        });
+
+        const glueData: GlueNotificationData = {
+            clickInterop: settings.clickInterop,
+            actions: settings.actions,
+            id
+        };
+
+        if (options.data) {
+            options.data.glueData = glueData;
+        } else {
+            options.data = { glueData };
+        }
+
+        await this.serviceWorkerRegistration.showNotification(settings.title, options);
+    }
+
+    public notifyReady(): void {
+        if (this._serviceWorkerRegistration) {
+            this.channel.postMessage({ platformStarted: true });
+        }
+    }
+
+    public onNotificationClick(callback: (clickData: { action: string; glueData: GlueNotificationData; definition: Glue42Web.Notifications.NotificationDefinition }) => void): UnsubscribeFunction {
+        return this.registry.add("notification-click", callback);
+    }
+
+    private setUpBroadcastChannelConnection(): void {
+        this.channel = new BroadcastChannel(serviceWorkerBroadcastChannelName);
+
+        this.channel.addEventListener("message", async (event) => {
+
+            const eventData = event.data;
+            const messageType: string = eventData?.messageType;
+
+            if (!messageType) {
+                return;
+            }
+
+            if (messageType === "ping") {
+                this.channel.postMessage({ pong: true });
+                return;
+            }
+
+            if (messageType === "notificationClick") {
+                const action = eventData.action as string;
+                const glueData = eventData.glueData;
+
+                const definition: Glue42Web.Notifications.NotificationDefinition = eventData.definition;
+
+                this.registry.execute("notification-click", { action, glueData, definition });
+                return;
+            }
+
+            if (messageType === "notificationError") {
+                this.logger?.error(`Service worker error when raising notification: ${eventData.error}`);
+                return;
+            }
+
+        });
+    }
+
+    private async registerWorker(workerUrl: string): Promise<ServiceWorkerRegistration | undefined> {
+
+        if (!("serviceWorker" in navigator)) {
+            this.logger?.warn(`A defined service worker has not been registered at ${workerUrl} because this browser does not support it.`);
+            return;
+        }
+
+        try {
+            const registration = await navigator.serviceWorker.register(workerUrl);
+
+            return registration;
+        } catch (error) {
+            const stringError = typeof error === "string" ? error : JSON.stringify(error.message);
+
+            this.logger?.warn(stringError);
+        }
+    }
+
+    private async waitRegistration(registrationPromise: Promise<ServiceWorkerRegistration>): Promise<ServiceWorkerRegistration> {
+
+        if (typeof registrationPromise.then !== "function" || typeof registrationPromise.catch !== "function") {
+            throw new Error("The provided service worker registration promise is not a promise");
+        }
+
+        const registration = await registrationPromise;
+
+        if (typeof registration.showNotification !== "function") {
+            throw new Error("The provided registration promise is a promise, but it resolved with an object which does not appear to be a ServiceWorkerRegistration");
+        }
+
+        return registration;
+    }
+}

--- a/packages/web-platform/src/controllers/state.ts
+++ b/packages/web-platform/src/controllers/state.ts
@@ -7,7 +7,7 @@ import {
 import { Glue42Core } from "@glue42/core";
 import logger from "../shared/logger";
 
-export class StateController {
+export class WindowsStateController {
     private readonly registry: CallbackRegistry = CallbackRegistryFactory();
     private readonly checkIntervalMs = 500;
     private childrenToCheck: Array<{ window: Window; windowId: string }> = [];

--- a/packages/web-platform/src/libs/applications/controller.ts
+++ b/packages/web-platform/src/libs/applications/controller.ts
@@ -5,7 +5,7 @@ import { generate } from "shortid";
 import { ApplicationStartConfig, BridgeOperation, InternalApplicationsConfig, InternalPlatformConfig, LibController, SessionWindowData } from "../../common/types";
 import { GlueController } from "../../controllers/glue";
 import { SessionStorageController } from "../../controllers/session";
-import { StateController } from "../../controllers/state";
+import { WindowsStateController } from "../../controllers/state";
 import { IoC } from "../../shared/ioc";
 import { PromiseWrap } from "../../shared/promisePlus";
 import { getRelativeBounds } from "../../shared/utils";
@@ -42,7 +42,7 @@ export class ApplicationsController implements LibController {
     constructor(
         private readonly glueController: GlueController,
         private readonly sessionStorage: SessionStorageController,
-        private readonly stateController: StateController,
+        private readonly stateController: WindowsStateController,
         private readonly appDirectory: AppDirectory,
         private readonly ioc: IoC
     ) { }

--- a/packages/web-platform/src/libs/notifications/controller.ts
+++ b/packages/web-platform/src/libs/notifications/controller.ts
@@ -1,0 +1,182 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Glue42Web } from "@glue42/web";
+import { BridgeOperation, LibController } from "../../common/types";
+import { GlueController } from "../../controllers/glue";
+import { ServiceWorkerController } from "../../controllers/serviceWorker";
+import logger from "../../shared/logger";
+import { notificationsOperationDecoder, permissionRequestResultDecoder, raiseNotificationDecoder } from "./decoders";
+import { GlueNotificationData, NotificationEventPayload, NotificationsOperationsTypes, PermissionRequestResult, RaiseNotificationConfig } from "./types";
+
+export class NotificationsController implements LibController {
+
+    private started = false;
+
+    private operations: { [key in NotificationsOperationsTypes]: BridgeOperation } = {
+        raiseNotification: { name: "raiseNotification", execute: this.handleRaiseNotification.bind(this), dataDecoder: raiseNotificationDecoder },
+        requestPermission: { name: "requestPermission", resultDecoder: permissionRequestResultDecoder, execute: this.handleRequestPermission.bind(this) }
+    }
+
+    constructor(
+        private readonly glueController: GlueController,
+        private readonly serviceWorkerController: ServiceWorkerController
+    ) { }
+
+    private get logger(): Glue42Web.Logger.API | undefined {
+        return logger.get("notifications.controller");
+    }
+
+    public async start(): Promise<void> {
+
+        this.started = true;
+
+        this.serviceWorkerController.onNotificationClick(this.handleNotificationClick.bind(this));
+    }
+
+    private handleNotificationClick(clickData: { action: string; glueData: GlueNotificationData; definition: Glue42Web.Notifications.NotificationDefinition }): void {
+        if (!clickData.action && clickData.glueData?.clickInterop) {
+            this.callDefinedInterop(clickData.glueData?.clickInterop);
+        }
+
+        if (clickData.action && clickData.glueData?.actions?.some((actionDef) => actionDef.action === clickData.action)) {
+            // this is a safe cast, because of the checks above
+            const notificationInteropAction = clickData.glueData?.actions?.find((action) => action.action === clickData.action) as Glue42Web.Notifications.NotificationAction;
+
+            if (notificationInteropAction.interop) {
+                this.callDefinedInterop(notificationInteropAction.interop);
+            }
+        }
+
+        if (clickData.definition.data?.glueData) {
+            delete clickData.definition.data.glueData;
+        }
+
+        const notificationEventPayload: NotificationEventPayload = {
+            definition: clickData.definition,
+            action: clickData.action,
+            id: clickData.glueData?.id
+        };
+
+        this.glueController.pushSystemMessage("notifications", "notificationClick", notificationEventPayload);
+    }
+
+    public async handleControl(args: any): Promise<any> {
+        if (!this.started) {
+            new Error("Cannot handle this notifications control message, because the controller has not been started");
+        }
+
+        const notificationsData = args.data;
+
+        const commandId = args.commandId;
+
+        const operationValidation = notificationsOperationDecoder.run(args.operation);
+
+        if (!operationValidation.ok) {
+            throw new Error(`This notifications request cannot be completed, because the operation name did not pass validation: ${JSON.stringify(operationValidation.error)}`);
+        }
+
+        const operationName: NotificationsOperationsTypes = operationValidation.result;
+
+        const incomingValidation = this.operations[operationName].dataDecoder?.run(notificationsData);
+
+        if (incomingValidation && !incomingValidation.ok) {
+            throw new Error(`Notifications request for ${operationName} rejected, because the provided arguments did not pass the validation: ${JSON.stringify(incomingValidation.error)}`);
+        }
+
+        this.logger?.debug(`[${commandId}] ${operationName} command is valid with data: ${JSON.stringify(notificationsData)}`);
+
+        const result = await this.operations[operationName].execute(notificationsData, commandId);
+
+        const resultValidation = this.operations[operationName].resultDecoder?.run(result);
+
+        if (resultValidation && !resultValidation.ok) {
+            throw new Error(`Notifications request for ${operationName} could not be completed, because the operation result did not pass the validation: ${JSON.stringify(resultValidation.error)}`);
+        }
+
+        this.logger?.trace(`[${commandId}] ${operationName} command was executed successfully`);
+
+        return result;
+    }
+
+    private async handleRaiseNotification({ settings, id }: RaiseNotificationConfig, commandId: string): Promise<void> {
+        this.logger?.trace(`[${commandId}] handling a raise notification message with a title: ${settings.title}`);
+
+        const hasDefinedActions = settings.actions && settings.actions.length;
+
+        if (hasDefinedActions) {
+
+            this.logger?.trace(`[${commandId}] notification with a title: ${settings.title} was found to be persistent and therefore the service worker will be instructed to raise it.`);
+
+            await this.serviceWorkerController.showNotification(settings, id);
+        } else {
+            this.logger?.trace(`[${commandId}] notification with a title: ${settings.title} was found to be non-persistent and therefore will be raised with the native notifications API`);
+
+            this.raiseSimpleNotification(settings, id);
+        }
+
+        const definition = Object.assign({}, settings, { title: undefined, clickInterop: undefined, actions: undefined });
+
+        const notificationEventPayload: NotificationEventPayload = { definition, id };
+
+        // setImmediate allows the client which raises the event, to resolve the raise promise before receiving the show event
+        // which in turn allows the user to not miss the event
+        setTimeout(() => this.glueController.pushSystemMessage("notifications", "notificationShow", notificationEventPayload), 0);
+
+        this.logger?.trace(`[${commandId}] notification with a title: ${settings.title} was successfully raised`);
+    }
+
+    private async handleRequestPermission(_: unknown, commandId: string): Promise<PermissionRequestResult> {
+        this.logger?.trace(`[${commandId}] handling a request permission message`);
+
+        const permissionValue = await Notification.requestPermission();
+
+        const permissionGranted = permissionValue === "granted";
+
+        this.logger?.trace(`[${commandId}] permission for raising notifications is: ${permissionValue}`);
+
+        return { permissionGranted };
+    }
+
+    private callDefinedInterop(interopConfig: Glue42Web.Notifications.InteropActionSettings): void {
+        const method = interopConfig.method;
+        const args = interopConfig.arguments;
+        const target = interopConfig.target;
+
+        this.glueController.invokeMethod(method, args, target)
+            .catch((err) => {
+                const stringError = typeof err === "string" ? err : JSON.stringify(err.message);
+                this.logger?.warn(`The interop invocation defined in the clickInterop was rejected, reason: ${stringError}`);
+            });
+    }
+
+    private raiseSimpleNotification(settings: Glue42Web.Notifications.RaiseOptions, id: string): void {
+        const options: NotificationOptions = Object.assign({}, settings, { title: undefined, clickInterop: undefined });
+
+        const notification = new Notification(settings.title, options);
+
+        notification.onclick = (event: any): void => {
+            const glueData: GlueNotificationData = {
+                id,
+                clickInterop: settings.clickInterop
+            };
+
+            const definition = {
+                badge: event.target.badge,
+                body: event.target.body,
+                data: event.target.data,
+                dir: event.target.dir,
+                icon: event.target.icon,
+                image: event.target.image,
+                lang: event.target.lang,
+                renotify: event.target.renotify,
+                requireInteraction: event.target.requireInteraction,
+                silent: event.target.silent,
+                tag: event.target.tag,
+                timestamp: event.target.timestamp,
+                vibrate: event.target.vibrate
+            };
+
+            this.handleNotificationClick({ action: "", glueData, definition });
+        };
+    }
+
+}

--- a/packages/web-platform/src/libs/notifications/decoders.ts
+++ b/packages/web-platform/src/libs/notifications/decoders.ts
@@ -1,0 +1,58 @@
+import { Glue42Web } from "@glue42/web";
+import { anyJson, array, boolean, constant, Decoder, number, object, oneOf, optional, string } from "decoder-validate";
+import { nonEmptyStringDecoder, nonNegativeNumberDecoder } from "../../shared/decoders";
+import { NotificationsOperationsTypes, PermissionRequestResult, RaiseNotificationConfig } from "./types";
+
+export const notificationsOperationDecoder: Decoder<NotificationsOperationsTypes> = oneOf<"raiseNotification" | "requestPermission">(
+    constant("raiseNotification"),
+    constant("requestPermission")
+);
+
+
+const interopActionSettingsDecoder: Decoder<Glue42Web.Notifications.InteropActionSettings> = object({
+    method: nonEmptyStringDecoder,
+    arguments: optional(anyJson()),
+    target: optional(oneOf<"all" | "best">(
+        constant("all"),
+        constant("best")
+    ))
+});
+
+const glue42NotificationActionDecoder: Decoder<Glue42Web.Notifications.NotificationAction> = object({
+    action: string(),
+    title: nonEmptyStringDecoder,
+    icon: optional(string()),
+    interop: optional(interopActionSettingsDecoder)
+});
+
+const glue42NotificationOptionsDecoder: Decoder<Glue42Web.Notifications.RaiseOptions> = object({
+    title: nonEmptyStringDecoder,
+    clickInterop: optional(interopActionSettingsDecoder),
+    actions: optional(array(glue42NotificationActionDecoder)),
+    badge: optional(string()),
+    body: optional(string()),
+    data: optional(anyJson()),
+    dir: optional(oneOf<"auto" | "ltr" | "rtl">(
+        constant("auto"),
+        constant("ltr"),
+        constant("rtl")
+    )),
+    icon: optional(string()),
+    image: optional(string()),
+    lang: optional(string()),
+    renotify: optional(boolean()),
+    requireInteraction: optional(boolean()),
+    silent: optional(boolean()),
+    tag: optional(string()),
+    timestamp: optional(nonNegativeNumberDecoder),
+    vibrate: optional(array(number()))
+});
+
+export const raiseNotificationDecoder: Decoder<RaiseNotificationConfig> = object({
+    settings: glue42NotificationOptionsDecoder,
+    id: nonEmptyStringDecoder
+});
+
+export const permissionRequestResultDecoder: Decoder<PermissionRequestResult> = object({
+    permissionGranted: boolean()
+});

--- a/packages/web-platform/src/libs/notifications/types.ts
+++ b/packages/web-platform/src/libs/notifications/types.ts
@@ -1,0 +1,24 @@
+import { Glue42Web } from "@glue42/web";
+
+export type NotificationsOperationsTypes = "raiseNotification" | "requestPermission";
+
+export interface RaiseNotificationConfig {
+    settings: Glue42Web.Notifications.RaiseOptions;
+    id: string;
+}
+
+export interface GlueNotificationData {
+    clickInterop?: Glue42Web.Notifications.InteropActionSettings;
+    actions?: Glue42Web.Notifications.NotificationAction[];
+    id: string;
+}
+
+export interface PermissionRequestResult {
+    permissionGranted: boolean;
+}
+
+export interface NotificationEventPayload {
+    definition: Glue42Web.Notifications.NotificationDefinition;
+    action?: string;
+    id?: string;
+}

--- a/packages/web-platform/src/libs/windows/controller.ts
+++ b/packages/web-platform/src/libs/windows/controller.ts
@@ -2,16 +2,16 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Glue42Web } from "@glue42/web";
 import { generate } from "shortid";
-import { BridgeOperation, CoreClientData, InternalPlatformConfig, LibController, SessionWindowData } from "../../common/types";
+import { BridgeOperation, InternalPlatformConfig, LibController, SessionWindowData } from "../../common/types";
 import { GlueController } from "../../controllers/glue";
 import { SessionStorageController } from "../../controllers/session";
 import { PromiseWrap } from "../../shared/promisePlus";
 import { frameWindowBoundsResultDecoder, openWindowConfigDecoder, simpleWindowDecoder, windowBoundsResultDecoder, windowMoveResizeConfigDecoder, windowOperationDecoder, windowTitleConfigDecoder, windowUrlResultDecoder } from "./decoders";
-import { StateController } from "../../controllers/state";
+import { WindowsStateController } from "../../controllers/state";
 import { HelloSuccess, OpenWindowConfig, OpenWindowSuccess, SimpleWindowCommand, WindowBoundsResult, WindowMoveResizeConfig, WindowOperationsTypes, WindowTitleConfig, WindowUrlResult } from "./types";
 import { getRelativeBounds } from "../../shared/utils";
 import logger from "../../shared/logger";
-import { SimpleItemConfig, WorkspaceWindowData } from "../workspaces/types";
+import { WorkspaceWindowData } from "../workspaces/types";
 import { workspaceWindowDataDecoder } from "../workspaces/decoders";
 import { IoC } from "../../shared/ioc";
 
@@ -38,7 +38,7 @@ export class WindowsController implements LibController {
     constructor(
         private readonly glueController: GlueController,
         private readonly sessionController: SessionStorageController,
-        private readonly stateController: StateController,
+        private readonly stateController: WindowsStateController,
         private readonly ioc: IoC
     ) { }
 

--- a/packages/web-platform/src/libs/workspaces/controller.ts
+++ b/packages/web-platform/src/libs/workspaces/controller.ts
@@ -11,7 +11,7 @@ import { Glue42WebPlatform } from "../../../platform";
 import { GlueController } from "../../controllers/glue";
 import { IoC } from "../../shared/ioc";
 import { FrameWindowBoundsResult, SimpleWindowCommand, WindowMoveResizeConfig } from "../windows/types";
-import { StateController } from "../../controllers/state";
+import { WindowsStateController } from "../../controllers/state";
 import { WorkspaceHibernationWatcher } from "./hibernationWatcher";
 import { workspacesConfigDecoder } from "../../shared/decoders";
 import deepMerge from "deepmerge";
@@ -63,7 +63,7 @@ export class WorkspacesController implements LibController {
     constructor(
         private readonly framesController: FramesController,
         private readonly glueController: GlueController,
-        private readonly stateController: StateController,
+        private readonly stateController: WindowsStateController,
         private readonly hibernationWatcher: WorkspaceHibernationWatcher,
         private readonly ioc: IoC
     ) { }

--- a/packages/web-platform/src/shared/decoders.ts
+++ b/packages/web-platform/src/shared/decoders.ts
@@ -71,13 +71,14 @@ export const windowLayoutComponentDecoder: Decoder<Glue42Web.Layouts.WindowCompo
     })
 });
 
-export const libDomainDecoder: Decoder<LibDomains> = oneOf<"system" | "windows" | "appManager" | "layouts" | "workspaces" | "intents">(
+export const libDomainDecoder: Decoder<LibDomains> = oneOf<"system" | "windows" | "appManager" | "layouts" | "workspaces" | "intents" | "notifications">(
     constant("system"),
     constant("windows"),
     constant("appManager"),
     constant("layouts"),
     constant("workspaces"),
-    constant("intents")
+    constant("intents"),
+    constant("notifications")
 );
 
 export const systemOperationTypesDecoder: Decoder<SystemOperationTypes> = oneOf<"getEnvironment" | "getBase">(
@@ -305,12 +306,18 @@ export const windowsConfigDecoder: Decoder<Glue42WebPlatform.Windows.Config> = o
     }))
 });
 
+export const serviceWorkerConfigDecoder: Decoder<Glue42WebPlatform.ServiceWorker.Config> = object({
+    url: optional(nonEmptyStringDecoder),
+    registrationPromise: optional(anyJson())
+});
+
 export const platformConfigDecoder: Decoder<Glue42WebPlatform.Config> = object({
     windows: optional(windowsConfigDecoder),
     applications: optional(applicationsConfigDecoder),
     layouts: optional(layoutsConfigDecoder),
     channels: optional(channelsConfigDecoder),
     plugins: optional(pluginsConfigDecoder),
+    serviceWorker: optional(serviceWorkerConfigDecoder),
     gateway: optional(gatewayConfigDecoder),
     glue: optional(glueConfigDecoder),
     workspaces: optional(workspacesConfigDecoder),

--- a/packages/web-platform/src/shared/ioc.ts
+++ b/packages/web-platform/src/shared/ioc.ts
@@ -6,7 +6,7 @@ import { GlueController } from "../controllers/glue";
 import { PortsBridge } from "../connection/portsBridge";
 import { WindowsController } from "../libs/windows/controller";
 import { SessionStorageController } from "../controllers/session";
-import { StateController } from "../controllers/state";
+import { WindowsStateController } from "../controllers/state";
 import { ApplicationsController } from "../libs/applications/controller";
 import { LayoutsController } from "../libs/layouts/controller";
 import { IdbStore } from "../libs/layouts/idbStore";
@@ -18,6 +18,8 @@ import { WorkspaceHibernationWatcher } from "../libs/workspaces/hibernationWatch
 import { SystemController } from "../controllers/system";
 import { AppDirectory } from "../libs/applications/appStore/directory";
 import { RemoteWatcher } from "../libs/applications/appStore/remoteWatcher";
+import { ServiceWorkerController } from "../controllers/serviceWorker";
+import { NotificationsController } from "../libs/notifications/controller";
 
 export class IoC {
     private _gatewayInstance!: Gateway;
@@ -34,11 +36,13 @@ export class IoC {
     private _hibernationWatcher!: WorkspaceHibernationWatcher;
     private _intentsController!: IntentsController;
     private _channelsController!: ChannelsController;
+    private _notificationsController!: NotificationsController;
     private _sessionController!: SessionStorageController;
-    private _stateChecker!: StateController;
+    private _stateChecker!: WindowsStateController;
     private _framesController!: FramesController;
     private _systemController!: SystemController;
     private _idbStore!: IdbStore;
+    private _serviceWorkerController!: ServiceWorkerController;
 
     constructor(private readonly config?: Glue42WebPlatform.Config) { }
 
@@ -69,8 +73,10 @@ export class IoC {
                 this.workspacesController,
                 this.intentsController,
                 this.channelsController,
+                this.notificationsController,
                 this.portsBridge,
-                this.stateController
+                this.stateController,
+                this.serviceWorkerController
             );
         }
 
@@ -101,9 +107,9 @@ export class IoC {
         return this._sessionController;
     }
 
-    public get stateController(): StateController {
+    public get stateController(): WindowsStateController {
         if (!this._stateChecker) {
-            this._stateChecker = new StateController(this.sessionController);
+            this._stateChecker = new WindowsStateController(this.sessionController);
         }
 
         return this._stateChecker;
@@ -207,6 +213,17 @@ export class IoC {
         return this._channelsController;
     }
 
+    public get notificationsController(): NotificationsController {
+        if (!this._notificationsController) {
+            this._notificationsController = new NotificationsController(
+                this.glueController,
+                this.serviceWorkerController
+            );
+        }
+
+        return this._notificationsController;
+    }
+
     public get framesController(): FramesController {
         if (!this._framesController) {
             this._framesController = new FramesController(
@@ -233,6 +250,14 @@ export class IoC {
         }
 
         return this._portsBridge;
+    }
+
+    public get serviceWorkerController(): ServiceWorkerController {
+        if (!this._serviceWorkerController) {
+            this._serviceWorkerController = new ServiceWorkerController();
+        }
+
+        return this._serviceWorkerController;
     }
 
     public createMessageChannel(): MessageChannel {

--- a/packages/web-worker/changelog.md
+++ b/packages/web-worker/changelog.md
@@ -1,0 +1,2 @@
+1.0.0
+feat: initial implementation of the package

--- a/packages/web-worker/package-lock.json
+++ b/packages/web-worker/package-lock.json
@@ -1,0 +1,782 @@
+{
+    "name": "@glue42/web-worker",
+    "version": "0.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+            "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.12.13"
+            }
+        },
+        "@babel/helper-validator-identifier": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+            "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+            "dev": true
+        },
+        "@babel/highlight": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+            "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.14.0",
+                "chalk": "^2.0.0",
+                "js-tokens": "^4.0.0"
+            }
+        },
+        "@rollup/plugin-commonjs": {
+            "version": "19.0.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-19.0.0.tgz",
+            "integrity": "sha512-adTpD6ATGbehdaQoZQ6ipDFhdjqsTgpOAhFiPwl+dzre4pPshsecptDPyEFb61JMJ1+mGljktaC4jI8ARMSNyw==",
+            "dev": true,
+            "requires": {
+                "@rollup/pluginutils": "^3.1.0",
+                "commondir": "^1.0.1",
+                "estree-walker": "^2.0.1",
+                "glob": "^7.1.6",
+                "is-reference": "^1.2.1",
+                "magic-string": "^0.25.7",
+                "resolve": "^1.17.0"
+            }
+        },
+        "@rollup/plugin-json": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+            "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+            "dev": true,
+            "requires": {
+                "@rollup/pluginutils": "^3.0.8"
+            }
+        },
+        "@rollup/plugin-node-resolve": {
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.0.tgz",
+            "integrity": "sha512-41X411HJ3oikIDivT5OKe9EZ6ud6DXudtfNrGbC4nniaxx2esiWjkLOzgnZsWq1IM8YIeL2rzRGLZLBjlhnZtQ==",
+            "dev": true,
+            "requires": {
+                "@rollup/pluginutils": "^3.1.0",
+                "@types/resolve": "1.17.1",
+                "builtin-modules": "^3.1.0",
+                "deepmerge": "^4.2.2",
+                "is-module": "^1.0.0",
+                "resolve": "^1.19.0"
+            }
+        },
+        "@rollup/pluginutils": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+            "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+            "dev": true,
+            "requires": {
+                "@types/estree": "0.0.39",
+                "estree-walker": "^1.0.1",
+                "picomatch": "^2.2.2"
+            },
+            "dependencies": {
+                "estree-walker": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+                    "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+                    "dev": true
+                }
+            }
+        },
+        "@types/estree": {
+            "version": "0.0.39",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+            "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "15.6.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
+            "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==",
+            "dev": true
+        },
+        "@types/resolve": {
+            "version": "1.17.1",
+            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+            "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/shortid": {
+            "version": "0.0.29",
+            "resolved": "https://registry.npmjs.org/@types/shortid/-/shortid-0.0.29.tgz",
+            "integrity": "sha1-gJPuBBam4r8qpjOBCRFLP7/6Dps=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
+        "builtin-modules": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+            "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+            "dev": true
+        },
+        "chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            }
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
+        },
+        "commondir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "decoder-validate": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/decoder-validate/-/decoder-validate-0.0.2.tgz",
+            "integrity": "sha512-9BsqAH9Zq6CvlxKHkSrZrH2iYlhuhHcrh6uTnDvcsa9P5YEweEzt1ci+X/9STgSCE7b9BA7/QIiwhfUDDWmjxw=="
+        },
+        "deepmerge": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+            "dev": true
+        },
+        "diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
+        },
+        "estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true
+        },
+        "find-cache-dir": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+            "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+            "dev": true,
+            "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^3.0.2",
+                "pkg-dir": "^4.1.0"
+            }
+        },
+        "find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dev": true,
+            "requires": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            }
+        },
+        "fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "optional": true
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.7",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+            "dev": true
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "is-core-module": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+            "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.3"
+            }
+        },
+        "is-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+            "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+            "dev": true
+        },
+        "is-reference": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+            "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+            "dev": true,
+            "requires": {
+                "@types/estree": "*"
+            }
+        },
+        "jest-worker": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+            "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^7.0.0"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dev": true,
+            "requires": {
+                "p-locate": "^4.1.0"
+            }
+        },
+        "magic-string": {
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+            "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+            "dev": true,
+            "requires": {
+                "sourcemap-codec": "^1.4.4"
+            }
+        },
+        "make-dir": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+            "dev": true,
+            "requires": {
+                "semver": "^6.0.0"
+            }
+        },
+        "merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.5"
+            }
+        },
+        "nanoid": {
+            "version": "2.1.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+            "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "requires": {
+                "p-try": "^2.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dev": true,
+            "requires": {
+                "p-limit": "^2.2.0"
+            }
+        },
+        "p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "dev": true
+        },
+        "path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
+        },
+        "picomatch": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+            "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+            "dev": true
+        },
+        "pkg-dir": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+            "dev": true,
+            "requires": {
+                "find-up": "^4.0.0"
+            }
+        },
+        "randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "resolve": {
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+            "dev": true,
+            "requires": {
+                "is-core-module": "^2.2.0",
+                "path-parse": "^1.0.6"
+            }
+        },
+        "rollup": {
+            "version": "2.50.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.50.1.tgz",
+            "integrity": "sha512-3MQhSdGpms4xjYrtR3WNHMT+VrWWM4oqUxUC770MmLo1FWFR2pr/OL81HSPC/ifmiu0uMFk0qPGLmjkSMRIESw==",
+            "dev": true,
+            "requires": {
+                "fsevents": "~2.3.1"
+            }
+        },
+        "rollup-plugin-terser": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+            "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "jest-worker": "^26.2.1",
+                "serialize-javascript": "^4.0.0",
+                "terser": "^5.0.0"
+            }
+        },
+        "rollup-plugin-typescript2": {
+            "version": "0.30.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.30.0.tgz",
+            "integrity": "sha512-NUFszIQyhgDdhRS9ya/VEmsnpTe+GERDMmFo0Y+kf8ds51Xy57nPNGglJY+W6x1vcouA7Au7nsTgsLFj2I0PxQ==",
+            "dev": true,
+            "requires": {
+                "@rollup/pluginutils": "^4.1.0",
+                "find-cache-dir": "^3.3.1",
+                "fs-extra": "8.1.0",
+                "resolve": "1.20.0",
+                "tslib": "2.1.0"
+            },
+            "dependencies": {
+                "@rollup/pluginutils": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
+                    "integrity": "sha512-TrBhfJkFxA+ER+ew2U2/fHbebhLT/l/2pRk0hfj9KusXUuRXd2v0R58AfaZK9VXDQ4TogOSEmICVrQAA3zFnHQ==",
+                    "dev": true,
+                    "requires": {
+                        "estree-walker": "^2.0.1",
+                        "picomatch": "^2.2.2"
+                    }
+                }
+            }
+        },
+        "safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true
+        },
+        "semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true
+        },
+        "serialize-javascript": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+            "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+            "dev": true,
+            "requires": {
+                "randombytes": "^2.1.0"
+            }
+        },
+        "shortid": {
+            "version": "2.2.16",
+            "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
+            "integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
+            "requires": {
+                "nanoid": "^2.1.0"
+            }
+        },
+        "source-map": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+            "dev": true
+        },
+        "source-map-support": {
+            "version": "0.5.19",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+            "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "sourcemap-codec": {
+            "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+            "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+            "dev": true
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^3.0.0"
+            }
+        },
+        "terser": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.0.tgz",
+            "integrity": "sha512-HP5/9hp2UaZt5fYkuhNBR8YyRcT8juw8+uFbAme53iN9hblvKnLUTKkmwJG6ocWpIKf8UK4DoeWG4ty0J6S6/g==",
+            "dev": true,
+            "requires": {
+                "commander": "^2.20.0",
+                "source-map": "~0.7.2",
+                "source-map-support": "~0.5.19"
+            }
+        },
+        "tslib": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+            "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+            "dev": true
+        },
+        "tslint": {
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
+            "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^4.0.1",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.13.1",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.3",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.13.0",
+                "tsutils": "^2.29.0"
+            },
+            "dependencies": {
+                "builtin-modules": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                    "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                },
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
+                }
+            }
+        },
+        "tsutils": {
+            "version": "2.29.0",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+            "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.8.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
+                }
+            }
+        },
+        "typescript": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+            "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+            "dev": true
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        }
+    }
+}

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -1,0 +1,54 @@
+{
+    "name": "@glue42/web-worker",
+    "version": "0.0.0",
+    "main": "dist/web.worker.umd.js",
+    "module": "dist/web.worker.es.js",
+    "types": "./web.worker.d.ts",
+    "scripts": {
+        "build": "rollup -c",
+        "test": "echo \"Error: no test specified\"",
+        "audit": "node ../../scripts/audit/index.js",
+        "preversion": "npm run build && npm run test && npm run audit",
+        "version": "npm run build"
+    },
+    "keywords": [
+        "glue",
+        "glue42",
+        "desktop",
+        "web",
+        "service worker"
+    ],
+    "description": "Glue42 Core service worker module",
+    "author": {
+        "name": "Glue42",
+        "url": "https://docs.glue42.com/"
+    },
+    "license": "MIT",
+    "publishConfig": {
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Glue42/core.git"
+    },
+    "homepage": "https://docs.glue42.com/",
+    "files": [
+        "dist"
+    ],
+    "devDependencies": {
+        "@rollup/plugin-commonjs": "^19.0.0",
+        "@rollup/plugin-json": "^4.1.0",
+        "@rollup/plugin-node-resolve": "^13.0.0",
+        "@types/node": "^15.6.1",
+        "@types/shortid": "0.0.29",
+        "rollup": "^2.50.1",
+        "rollup-plugin-terser": "^7.0.2",
+        "rollup-plugin-typescript2": "^0.30.0",
+        "tslint": "^6.1.3",
+        "typescript": "^4.3.2"
+    },
+    "dependencies": {
+        "decoder-validate": "0.0.2",
+        "shortid": "^2.2.16"
+    }
+}

--- a/packages/web-worker/rollup.config.js
+++ b/packages/web-worker/rollup.config.js
@@ -1,0 +1,53 @@
+import typescript from 'rollup-plugin-typescript2';
+import { terser } from 'rollup-plugin-terser';
+import commonjs from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
+import json from '@rollup/plugin-json';
+import pkg from './package.json';
+
+export default {
+    input: 'src/index.ts',
+    output: [
+        {
+            file: pkg.main,
+            name: 'web.worker',
+            format: 'umd',
+            sourcemap: true
+        },
+        {
+            file: './dist/web.worker.umd.min.js',
+            name: 'web.worker.min',
+            format: 'umd',
+            sourcemap: true,
+            plugins: [terser()]
+        },
+        {
+            file: pkg.module,
+            format: 'es',
+            sourcemap: true
+        },
+    ],
+    external: [
+        //...Object.keys(pkg.dependencies || {}),
+        ...Object.keys(pkg.peerDependencies || {}),
+    ],
+
+    plugins: [
+        typescript({
+            typescript: require('typescript')
+        }),
+        // Allow json resolution
+        json(),
+        // // Allow bundling cjs modules (unlike webpack, rollup doesn't understand cjs)
+        commonjs(),
+        // // Allow node_modules resolution, so you can use 'external' to control
+        // // which external modules to include in the bundle
+        // // https://github.com/rollup/rollup-plugin-node-resolve#usage
+        resolve({
+            mainFields: ['module', 'main', 'browser']
+        }),
+
+        // // Resolve source maps to the original source
+        // sourceMaps(),
+    ],
+};

--- a/packages/web-worker/src/constants.ts
+++ b/packages/web-worker/src/constants.ts
@@ -1,0 +1,3 @@
+export const serviceWorkerBroadcastChannelName = "glue42-core-worker";
+export const platformPingTimeoutMS = 3000;
+export const platformOpenTimeoutMS = 60000;

--- a/packages/web-worker/src/decoders.ts
+++ b/packages/web-worker/src/decoders.ts
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { anyJson, array, boolean, Decoder, fail, object, optional, string } from "decoder-validate";
+import { Glue42NotificationClickHandler, WebWorkerConfig } from "../web.worker";
+
+export const nonEmptyStringDecoder: Decoder<string> = string().where((s) => s.length > 0, "Expected a non-empty string");
+
+const functionCheck = (input: any, propDescription: string): Decoder<any> => {
+    const providedType = typeof input;
+
+    return providedType === "function" ?
+        anyJson() :
+        fail(`The provided argument as ${propDescription} should be of type function, provided: ${typeof providedType}`);
+};
+
+export const glue42NotificationClickHandlerDecoder: Decoder<Glue42NotificationClickHandler> = object({
+    action: nonEmptyStringDecoder,
+    handler: anyJson().andThen((result) => functionCheck(result, "handler"))
+});
+
+export const webWorkerConfigDecoder: Decoder<WebWorkerConfig> = object({
+    platform: optional(object({
+        url: nonEmptyStringDecoder,
+        openIfMissing: optional(boolean())
+    })),
+    notifications: optional(object({
+        defaultClick: optional(anyJson().andThen((result) => functionCheck(result, "defaultClick"))),
+        actionClicks: optional(array(glue42NotificationClickHandlerDecoder))
+    }))
+});

--- a/packages/web-worker/src/index.ts
+++ b/packages/web-worker/src/index.ts
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { setupCore, openCorePlatform, raiseGlueNotification } from "./worker";
+
+if (typeof self !== "undefined") {
+    (self as any).GlueWebWorker = setupCore;
+    (self as any).openCorePlatform = openCorePlatform;
+    (self as any).raiseGlueNotification = raiseGlueNotification;
+}
+
+export default setupCore;

--- a/packages/web-worker/src/worker.ts
+++ b/packages/web-worker/src/worker.ts
@@ -1,0 +1,151 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Glue42WebWorkerFactoryFunction, WebWorkerConfig } from "../web.worker";
+import { platformOpenTimeoutMS, platformPingTimeoutMS, serviceWorkerBroadcastChannelName } from "./constants";
+import { webWorkerConfigDecoder } from "./decoders";
+import { generate } from "shortid";
+
+const checkPlatformOpen = (): Promise<boolean> => {
+    const checkPromise = new Promise<boolean>((resolve) => {
+        const channel = new BroadcastChannel(serviceWorkerBroadcastChannelName);
+
+        const existenceHandler = function (event: any): void {
+            const data = event.data;
+
+            if (data.pong) {
+                channel.removeEventListener("message", existenceHandler);
+                resolve(true);
+            }
+        };
+
+        channel.addEventListener("message", existenceHandler);
+
+        channel.postMessage({ messageType: "ping" });
+    });
+
+    const timeoutPromise = new Promise<boolean>((resolve) => setTimeout(() => resolve(false), platformPingTimeoutMS));
+
+    return Promise.race([checkPromise, timeoutPromise]);
+};
+
+const validateConfig = (config: WebWorkerConfig = {}): WebWorkerConfig => {
+    const validated = webWorkerConfigDecoder.runWithException(config);
+
+    return validated;
+};
+
+export const raiseGlueNotification = async (settings: any): Promise<void> => {
+
+    const options = Object.assign({}, settings, { title: undefined, clickInterop: undefined, actions: undefined });
+
+    options.actions = settings.actions?.map((action: any) => {
+        return {
+            action: action.action,
+            title: action.title,
+            icon: action.icon
+        };
+    });
+
+    const glueData = {
+        clickInterop: settings.clickInterop,
+        actions: settings.actions,
+        id: generate()
+    };
+
+    if (options.data) {
+        options.data.glueData = glueData;
+    } else {
+        options.data = { glueData };
+    }
+
+    return (self as any).registration.showNotification(settings.title, options);
+};
+
+export const openCorePlatform = (url: string): Promise<void> => {
+    return new Promise((resolve, reject) => {
+
+        if (!url) {
+            return reject("Cannot open the platform, because a url was not provided");
+        }
+
+        const channel = new BroadcastChannel(serviceWorkerBroadcastChannelName);
+
+        const openHandler = function (event: any): void {
+            const data = event.data;
+
+            if (data.platformStarted) {
+                channel.removeEventListener("message", openHandler);
+                resolve();
+            }
+        };
+
+        channel.addEventListener("message", openHandler);
+
+        (self as any).clients.openWindow(url).catch(reject);
+
+        setTimeout(() => reject(`Timed out waiting for the platform to open and send a ready signal: ${platformOpenTimeoutMS} MS`), platformOpenTimeoutMS);
+    });
+};
+
+export const setupCore: Glue42WebWorkerFactoryFunction = (config?: WebWorkerConfig): void => {
+    const verifiedConfig = validateConfig(config);
+
+    self.addEventListener("notificationclick", (event: any) => {
+        let isPlatformOpen: boolean;
+
+        const channel = new BroadcastChannel(serviceWorkerBroadcastChannelName);
+
+        const executionPromise = checkPlatformOpen()
+            .then((platformExists: boolean) => {
+
+                isPlatformOpen = platformExists;
+
+                const action = event.action;
+
+                if (!action && verifiedConfig.notifications?.defaultClick) {
+                    return verifiedConfig.notifications.defaultClick(event, isPlatformOpen);
+                }
+
+                if (action && verifiedConfig.notifications?.actionClicks?.some((actionDef) => actionDef.action === action)) {
+                    const foundHandler = verifiedConfig.notifications.actionClicks.find((actionDef) => actionDef.action === action).handler;
+
+                    return foundHandler(event, isPlatformOpen);
+                }
+            })
+            .then(() => {
+                if (!isPlatformOpen && verifiedConfig.platform?.openIfMissing) {
+                    return openCorePlatform(verifiedConfig.platform.url);
+                }
+            })
+            .then(() => {
+
+                const messageType = "notificationClick";
+
+                const action = (event as any).action;
+                const glueData = (event as any).notification.data.glueData;
+
+                const definition = {
+                    badge: (event as any).notification.badge,
+                    body: (event as any).notification.body,
+                    data: (event as any).notification.data,
+                    dir: (event as any).notification.dir,
+                    icon: (event as any).notification.icon,
+                    image: (event as any).notification.image,
+                    lang: (event as any).notification.lang,
+                    renotify: (event as any).notification.renotify,
+                    requireInteraction: (event as any).notification.requireInteraction,
+                    silent: (event as any).notification.silent,
+                    tag: (event as any).notification.tag,
+                    timestamp: (event as any).notification.timestamp,
+                    vibrate: (event as any).notification.vibrate
+                };
+
+                channel.postMessage({ messageType, action, glueData, definition });
+            })
+            .catch((error) => {
+                const stringError = typeof error === "string" ? error : JSON.stringify(error.message);
+                channel.postMessage({ messageType: "notificationError", error: stringError });
+            });
+
+        event.waitUntil(executionPromise);
+    });
+};

--- a/packages/web-worker/web.worker.d.ts
+++ b/packages/web-worker/web.worker.d.ts
@@ -1,0 +1,21 @@
+export interface Glue42NotificationClickHandler {
+    handler: (event: Event, isPlatformOpened: boolean) => Promise<void>;
+    action: string;
+}
+
+export interface WebWorkerConfig {
+    platform?: {
+        url: string;
+        openIfMissing?: boolean;
+    };
+    notifications?: {
+        defaultClick?: (event: Event, isPlatformOpened: boolean) => Promise<void>;
+        actionClicks?: Glue42NotificationClickHandler[];
+    };
+}
+
+export type Glue42WebWorkerFactoryFunction = (config?: WebWorkerConfig) => void;
+
+declare const WebWorkerFactory: Glue42WebWorkerFactoryFunction;
+
+export default WebWorkerFactory;

--- a/packages/web/changelog.md
+++ b/packages/web/changelog.md
@@ -1,3 +1,5 @@
+2.2.0
+feat: added support for advanced notifications
 2.1.8
 feat: windows lib can now handle bounds request when the window is a frame
 2.1.7

--- a/packages/web/src/appManager/controller.ts
+++ b/packages/web/src/appManager/controller.ts
@@ -5,7 +5,7 @@ import { Glue42Web } from "../../web";
 import { GlueBridge } from "../communication/bridge";
 import { allApplicationDefinitionsDecoder, appManagerOperationTypesDecoder, importModeDecoder, nonEmptyStringDecoder } from "../shared/decoders";
 import { IoC } from "../shared/ioc";
-import { LibController } from "../shared/types";
+import { LibController, ParsedConfig } from "../shared/types";
 import { WindowHello } from "../windows/protocol";
 import { AppsImportOperation, AppHelloSuccess, ApplicationStartConfig, AppRemoveConfig, InstanceData, operations, BaseApplicationData, AppsExportOperation, DefinitionParseResult } from "./protocol";
 import {

--- a/packages/web/src/config/index.ts
+++ b/packages/web/src/config/index.ts
@@ -1,4 +1,5 @@
 import { Glue42Web } from "../../web";
+import { ParsedConfig } from "../shared/types";
 
 const defaultConfig = {
     logger: "info",
@@ -7,7 +8,7 @@ const defaultConfig = {
 };
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export const parseConfig = (config?: Glue42Web.Config): any => {
+export const parseConfig = (config?: Glue42Web.Config): ParsedConfig => {
     const combined = Object.assign({}, defaultConfig, config);
 
     if (combined.systemLogger) {

--- a/packages/web/src/notifications/controller.ts
+++ b/packages/web/src/notifications/controller.ts
@@ -1,66 +1,137 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Glue42Core } from "@glue42/core";
 import { Glue42Web } from "../../web";
+import { GlueBridge } from "../communication/bridge";
+import { glue42NotificationOptionsDecoder, notificationsOperationTypesDecoder } from "../shared/decoders";
+import { IoC } from "../shared/ioc";
 import { LibController } from "../shared/types";
+import { NotificationEventPayload, operations, PermissionRequestResult, RaiseNotification } from "./protocol";
+import { generate } from "shortid";
 
 export class NotificationsController implements LibController {
     private logger!: Glue42Web.Logger.API;
-    private interop!: Glue42Core.AGM.API;
+    private bridge!: GlueBridge;
+    private notificationsSettings?: Glue42Web.Notifications.Settings;
+    private notifications: { [key in string]: Glue42Web.Notifications.Notification } = {};
+    private coreGlue!: Glue42Core.GlueCore;
+    private buildNotificationFunc!: (config: Glue42Web.Notifications.RaiseOptions) => Glue42Web.Notifications.Notification;
 
-    public async start(coreGlue: Glue42Core.GlueCore): Promise<void> {
+    public async start(coreGlue: Glue42Core.GlueCore, ioc: IoC): Promise<void> {
         this.logger = coreGlue.logger.subLogger("notifications.controller.web");
 
         this.logger.trace("starting the web notifications controller");
 
-        this.interop = coreGlue.interop;
+        this.bridge = ioc.bridge;
+
+        this.coreGlue = coreGlue;
+
+        this.notificationsSettings = ioc.config.notifications;
+
+        this.buildNotificationFunc = ioc.buildNotification;
 
         const api = this.toApi();
+
+        this.addOperationExecutors();
 
         (coreGlue as Glue42Web.API).notifications = api;
 
         this.logger.trace("notifications are ready");
     }
 
-    public async handleBridgeMessage(): Promise<void> {
-        // noop
+    public async handleBridgeMessage(args: any): Promise<void> {
+        const operationName = notificationsOperationTypesDecoder.runWithException(args.operation);
+
+        const operation = operations[operationName];
+
+        if (!operation.execute) {
+            return;
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        let operationData: any = args.data;
+
+        if (operation.dataDecoder) {
+            operationData = operation.dataDecoder.runWithException(args.data);
+        }
+
+        return await operation.execute(operationData);
     }
 
     private toApi(): Glue42Web.Notifications.API {
         const api: Glue42Web.Notifications.API = {
-            raise: this.raise.bind(this)
+            raise: this.raise.bind(this),
+            requestPermission: this.requestPermission.bind(this)
         };
 
         return Object.freeze(api);
     }
 
-    private async raise(options: Glue42Web.Notifications.Glue42NotificationOptions): Promise<Notification> {
+    private async requestPermission(): Promise<boolean> {
 
-        if (!("Notification" in window)) {
-            throw new Error("this browser does not support desktop notification");
+        const permissionResult = await this.bridge.send<void, PermissionRequestResult>("notifications", operations.requestPermission, undefined);
+
+        return permissionResult.permissionGranted;
+    }
+
+    private async raise(options: Glue42Web.Notifications.RaiseOptions): Promise<Glue42Web.Notifications.Notification> {
+        const settings = glue42NotificationOptionsDecoder.runWithException(options);
+
+        const permissionGranted = await this.requestPermission();
+
+        if (!permissionGranted) {
+            throw new Error("Cannot raise the notification, because the user has declined the permission request");
         }
-        let permissionPromise: Promise<NotificationPermission>;
-        if (Notification.permission === "granted") {
-            permissionPromise = Promise.resolve("granted");
-        } else if (Notification.permission === "denied") {
-            permissionPromise = Promise.reject("no permissions from user");
-        } else {
-            permissionPromise = Notification.requestPermission();
-        }
 
-        await permissionPromise;
+        const id = generate();
 
-        const notification = this.raiseUsingWebApi(options);
+        await this.bridge.send<RaiseNotification, void>("notifications", operations.raiseNotification, { settings, id });
 
-        if (options.clickInterop) {
-            const interopOptions = options.clickInterop;
-            notification.onclick = (): void => {
-                this.interop.invoke(interopOptions.method, interopOptions?.arguments ?? {}, interopOptions?.target ?? "best");
-            };
-        }
+        const notification = this.buildNotificationFunc(options);
+
+        this.notifications[id] = notification;
 
         return notification;
     }
 
-    private raiseUsingWebApi(options: Glue42Web.Notifications.Glue42NotificationOptions): Notification {
-        return new Notification(options.title);
+    private addOperationExecutors(): void {
+        operations.notificationShow.execute = this.handleNotificationShow.bind(this);
+        operations.notificationClick.execute = this.handleNotificationClick.bind(this);
+    }
+
+    private async handleNotificationShow(data: NotificationEventPayload): Promise<void> {
+
+        if (!data.id) {
+            return;
+        }
+
+        const notification = this.notifications[data.id];
+        if (notification && notification.onshow) {
+            notification.onshow();
+        }
+    }
+
+    private async handleNotificationClick(data: NotificationEventPayload): Promise<void> {
+
+        if (!data.action && this.notificationsSettings?.defaultClick) {
+            this.notificationsSettings.defaultClick(this.coreGlue as Glue42Web.API, data.definition);
+        }
+
+        if (data.action && this.notificationsSettings?.actionClicks?.some((actionDef) => actionDef.action === data.action)) {
+            const foundHandler = this.notificationsSettings?.actionClicks?.find((actionDef) => actionDef.action === data.action) as Glue42Web.Notifications.ActionClickHandler;
+
+            foundHandler.handler(this.coreGlue as Glue42Web.API, data.definition);
+        }
+
+        if (!data.id) {
+            return;
+        }
+
+        const notification = this.notifications[data.id];
+
+        if (notification && notification.onclick) {
+            notification.onclick();
+            delete this.notifications[data.id];
+        }
+
     }
 }

--- a/packages/web/src/notifications/notification.ts
+++ b/packages/web/src/notifications/notification.ts
@@ -1,0 +1,39 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Glue42Web } from "../../web";
+
+export class Notification implements Glue42Web.Notifications.Notification {
+
+    public onclick: () => any = () => { };
+    public onshow: () => any = () => { };
+    public badge?: string | undefined;
+    public body?: string | undefined;
+    public data?: any;
+    public dir?: "auto" | "ltr" | "rtl" | undefined;
+    public icon?: string | undefined;
+    public image?: string | undefined;
+    public lang?: string | undefined;
+    public renotify?: boolean | undefined;
+    public requireInteraction?: boolean | undefined;
+    public silent?: boolean | undefined;
+    public tag?: string | undefined;
+    public timestamp?: number | undefined;
+    public vibrate?: number[] | undefined;
+
+    constructor(config: Glue42Web.Notifications.RaiseOptions) {
+        this.badge = config.badge;
+        this.body = config.body;
+        this.data = config.data;
+        this.dir = config.dir;
+        this.icon = config.icon;
+        this.image = config.image;
+        this.lang = config.lang;
+        this.renotify = config.renotify;
+        this.requireInteraction = config.requireInteraction;
+        this.silent = config.silent;
+        this.tag = config.tag;
+        this.timestamp = config.timestamp;
+        this.vibrate = config.vibrate;
+    }
+
+}

--- a/packages/web/src/notifications/protocol.ts
+++ b/packages/web/src/notifications/protocol.ts
@@ -1,0 +1,27 @@
+import { Glue42Web } from "../../web";
+import { notificationEventPayloadDecoder, permissionRequestResultDecoder, raiseNotificationDecoder } from "../shared/decoders";
+import { BridgeOperation } from "../shared/types";
+
+export type NotificationsOperationTypes = "raiseNotification" | "requestPermission" | "notificationShow" | "notificationClick";
+
+export const operations: { [key in NotificationsOperationTypes]: BridgeOperation } = {
+    raiseNotification: { name: "raiseNotification", dataDecoder: raiseNotificationDecoder },
+    requestPermission: { name: "requestPermission", resultDecoder: permissionRequestResultDecoder },
+    notificationShow: { name: "notificationShow", dataDecoder: notificationEventPayloadDecoder },
+    notificationClick: { name: "notificationClick", dataDecoder: notificationEventPayloadDecoder }
+};
+
+export interface RaiseNotification {
+    settings: Glue42Web.Notifications.RaiseOptions;
+    id: string;
+}
+
+export interface PermissionRequestResult {
+    permissionGranted: boolean;
+}
+
+export interface NotificationEventPayload {
+    definition: Glue42Web.Notifications.NotificationDefinition;
+    action?: string;
+    id?: string;
+}

--- a/packages/web/src/shared/decoders.ts
+++ b/packages/web/src/shared/decoders.ts
@@ -6,6 +6,7 @@ import { AllLayoutsFullConfig, AllLayoutsSummariesResult, GetAllLayoutsConfig, L
 import { HelloSuccess, OpenWindowConfig, CoreWindowData, WindowHello, WindowOperationTypes, SimpleWindowCommand, WindowTitleConfig, WindowBoundsResult, WindowMoveResizeConfig, WindowUrlResult, FrameWindowBoundsResult } from "../windows/protocol";
 import { IntentsOperationTypes, WrappedIntentFilter, WrappedIntents } from "../intents/protocol";
 import { LibDomains } from "./types";
+import { NotificationEventPayload, NotificationsOperationTypes, PermissionRequestResult, RaiseNotification } from "../notifications/protocol";
 
 export const nonEmptyStringDecoder: Decoder<string> = string().where((s) => s.length > 0, "Expected a non-empty string");
 export const nonNegativeNumberDecoder: Decoder<number> = number().where((num) => num >= 0, "Expected a non-negative number");
@@ -56,6 +57,13 @@ export const layoutsOperationTypesDecoder: Decoder<LayoutsOperationTypes> = oneO
     constant("export"),
     constant("import"),
     constant("remove")
+);
+
+export const notificationsOperationTypesDecoder: Decoder<NotificationsOperationTypes> = oneOf<"raiseNotification" | "requestPermission" | "notificationShow" | "notificationClick">(
+    constant("raiseNotification"),
+    constant("requestPermission"),
+    constant("notificationShow"),
+    constant("notificationClick")
 );
 
 export const windowRelativeDirectionDecoder: Decoder<Glue42Web.Windows.RelativeDirection> = oneOf<"top" | "left" | "right" | "bottom">(
@@ -507,3 +515,77 @@ export const addIntentListenerIntentDecoder: Decoder<string | Glue42Web.Intents.
 export const channelNameDecoder = (channelNames: string[]): Decoder<string> => {
     return nonEmptyStringDecoder.where(s => channelNames.includes(s), "Expected a valid channel name");
 };
+
+export const interopActionSettingsDecoder: Decoder<Glue42Web.Notifications.InteropActionSettings> = object({
+    method: nonEmptyStringDecoder,
+    arguments: optional(anyJson()),
+    target: optional(oneOf<"all" | "best">(
+        constant("all"),
+        constant("best")
+    ))
+});
+
+export const glue42NotificationActionDecoder: Decoder<Glue42Web.Notifications.NotificationAction> = object({
+    action: string(),
+    title: nonEmptyStringDecoder,
+    icon: optional(string()),
+    interop: optional(interopActionSettingsDecoder)
+});
+
+export const notificationDefinitionDecoder: Decoder<Glue42Web.Notifications.NotificationDefinition> = object({
+    badge: optional(string()),
+    body: optional(string()),
+    data: optional(anyJson()),
+    dir: optional(oneOf<"auto" | "ltr" | "rtl">(
+        constant("auto"),
+        constant("ltr"),
+        constant("rtl")
+    )),
+    icon: optional(string()),
+    image: optional(string()),
+    lang: optional(string()),
+    renotify: optional(boolean()),
+    requireInteraction: optional(boolean()),
+    silent: optional(boolean()),
+    tag: optional(string()),
+    timestamp: optional(nonNegativeNumberDecoder),
+    vibrate: optional(array(number()))
+});
+
+export const glue42NotificationOptionsDecoder: Decoder<Glue42Web.Notifications.RaiseOptions> = object({
+    title: nonEmptyStringDecoder,
+    clickInterop: optional(interopActionSettingsDecoder),
+    actions: optional(array(glue42NotificationActionDecoder)),
+    badge: optional(string()),
+    body: optional(string()),
+    data: optional(anyJson()),
+    dir: optional(oneOf<"auto" | "ltr" | "rtl">(
+        constant("auto"),
+        constant("ltr"),
+        constant("rtl")
+    )),
+    icon: optional(string()),
+    image: optional(string()),
+    lang: optional(string()),
+    renotify: optional(boolean()),
+    requireInteraction: optional(boolean()),
+    silent: optional(boolean()),
+    tag: optional(string()),
+    timestamp: optional(nonNegativeNumberDecoder),
+    vibrate: optional(array(number()))
+});
+
+export const raiseNotificationDecoder: Decoder<RaiseNotification> = object({
+    settings: glue42NotificationOptionsDecoder,
+    id: nonEmptyStringDecoder
+});
+
+export const permissionRequestResultDecoder: Decoder<PermissionRequestResult> = object({
+    permissionGranted: boolean()
+});
+
+export const notificationEventPayloadDecoder: Decoder<NotificationEventPayload> = object({
+    definition: notificationDefinitionDecoder,
+    action: optional(string()),
+    id: optional(nonEmptyStringDecoder)
+});

--- a/packages/web/src/shared/ioc.ts
+++ b/packages/web/src/shared/ioc.ts
@@ -1,5 +1,5 @@
 import { WebWindowModel } from "../windows/webWindow";
-import { LibController, LibDomains } from "./types";
+import { LibController, LibDomains, ParsedConfig } from "./types";
 import { WindowsController } from "../windows/controller";
 import { Glue42Core } from "@glue42/core";
 import { GlueBridge } from "../communication/bridge";
@@ -14,8 +14,10 @@ import { NotificationsController } from "../notifications/controller";
 import { IntentsController } from "../intents/controller";
 import { ChannelsController } from "../channels/controller";
 import { SystemController } from "../system/controller";
+import { Notification } from "../notifications/notification";
 
 export class IoC {
+    private _webConfig!: ParsedConfig;
     private _windowsControllerInstance!: WindowsController;
     private _appManagerControllerInstance!: AppManagerController;
     private _layoutsControllerInstance!: LayoutsController;
@@ -100,6 +102,14 @@ export class IoC {
 
         return this._bridgeInstance;
     }
+    
+    public get config(): ParsedConfig {
+        return this._webConfig;
+    }
+
+    public defineConfig(config: ParsedConfig): void {
+        this._webConfig = config;
+    }
 
     public async buildWebWindow(id: string, name: string): Promise<WindowProjection> {
 
@@ -108,6 +118,10 @@ export class IoC {
         const api = await model.toApi();
 
         return { id, model, api };
+    }
+
+    public buildNotification(config: Glue42Web.Notifications.RaiseOptions): Glue42Web.Notifications.Notification {
+        return new Notification(config);
     }
 
     public async buildApplication(app: BaseApplicationData, applicationInstances: InstanceData[]): Promise<Glue42Web.AppManager.Application> {

--- a/packages/web/src/shared/types.ts
+++ b/packages/web/src/shared/types.ts
@@ -1,7 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Glue42Core } from "@glue42/core";
+import { Glue42 } from "@glue42/desktop";
 import { Decoder } from "decoder-validate";
+import { Glue42Web } from "../../web";
 import { IoC } from "./ioc";
+
+export interface ParsedConfig extends Glue42Web.Config {
+    logger: any;
+    libraries: Array<(glue: Glue42Web.API, config?: Glue42Web.Config | Glue42.Config) => Promise<void>>;
+}
 
 export interface LibController {
     start(coreGlue: Glue42Core.GlueCore, ioc: IoC): Promise<void>;

--- a/packages/web/src/web.ts
+++ b/packages/web/src/web.ts
@@ -32,6 +32,8 @@ export const createFactoryFunction = (coreFactoryFunction: GlueCoreFactoryFuncti
 
         await ioc.bridge.start(ioc.controllers);
 
+        ioc.defineConfig(config);
+
         logger.trace("the bridge has been started, initializing all controllers");
 
         await Promise.all(Object.values(ioc.controllers).map((controller) => controller.start(glue, ioc)));

--- a/packages/web/web.d.ts
+++ b/packages/web/web.d.ts
@@ -78,6 +78,11 @@ export namespace Glue42Web {
         inproc?: Glue42Core.InprocGWSettings;
 
         /**
+         * Configure the system logger. Used mostly for during development.
+         */
+        notifications?: Notifications.Settings;
+
+        /**
          * A list of glue libraries which will be initiated internally and provide access to specific functionalities
          */
         libraries?: Array<(glue: Glue42Web.API, config?: Glue42Web.Config | Glue42.Config) => Promise<void>>;
@@ -501,25 +506,63 @@ export namespace Glue42Web {
              * Raises a new notification
              * @param notification notification options
              */
-            raise(notification: Glue42NotificationOptions): Promise<Notification>;
+            raise(notification: RaiseOptions): Promise<Notification>;
+            requestPermission(): Promise<boolean>;
         }
 
-        export interface Glue42NotificationOptions extends NotificationOptions {
+        export interface NotificationDefinition {
+            badge?: string;
+            body?: string;
+            data?: any;
+            dir?: "auto" | "ltr" | "rtl";
+            icon?: string;
+            image?: string;
+            lang?: string;
+            renotify?: boolean;
+            requireInteraction?: boolean;
+            silent?: boolean;
+            tag?: string;
+            timestamp?: number;
+            vibrate?: number[];
+        }
+
+        export interface Notification extends NotificationDefinition {
+            onclick: () => any;
+            onshow: () => any;
+        }
+
+        export interface RaiseOptions extends NotificationDefinition {
             /** the title of the notification */
             title: string;
             /** set to make the notification click invoke an interop method with specific arguments */
             clickInterop?: InteropActionSettings;
+            actions?: NotificationAction[];
         }
 
-        export interface Glue42NotificationAction extends NotificationAction {
+        export interface NotificationAction {
+            action: string;
+            title: string;
+            icon?: string;
             /** set to make the action invoke an interop method with specific arguments */
-            interop: InteropActionSettings;
+            interop?: InteropActionSettings;
         }
 
         export interface InteropActionSettings {
             method: string;
             arguments?: any;
             target?: "all" | "best";
+        }
+
+        export type NotificationClickHandler = (glue: Glue42Web.API, notificationDefinition: NotificationDefinition) => void;
+
+        export interface ActionClickHandler {
+            action: string;
+            handler: NotificationClickHandler;
+        }
+
+        export interface Settings {
+            defaultClick: NotificationClickHandler;
+            actionClicks: ActionClickHandler[];
         }
     }
 


### PR DESCRIPTION
This PR allows users to raise notifications with all supported web settings:

- body
- badge
- data
- dir
- icon
- image
- lang
- renotify
- requireInteraction
- silent
- tag
- timestamp
- vibrate

The notifications can also be defined with glue-specific settinings:
- clickInterop -> an interop method will be invoked when the notification is clicked
- actions with interop settings -> an interop method will be invoked when the notification's action has been clicked

The PR also extends web-platform to accept Service Worker configuration - either a url or a registration promise. If a url is provided, the lib will check for compatibility and register the worker, if a promise is provided, the lib will just wait for the promise and the user can use the serviceWorkerRegistration elsewhere too.

All notifications, except those with actions, require a service worker.

A new package is being introduced: @glue42/web-worker. This package is intended to be used either by importing the module when building your own service worker or by calling importScript inside the worker can calling the globally defined functions.

This new package enables the communication with the platform and more specifically correctly opening the platform (if needed) and sending all of the instructions that come with the notification, including the interop settings.