### PR TITLE
Glue performance events backwards compatibility fix

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -305,7 +305,9 @@ const GlueCore = (userConfig?: Glue42Core.Config, ext?: Glue42Core.Extension): P
                     return {
                         name: key,
                         duration: t.endTime - t.startTime,
-                        marks: t.marks
+                        marks: t.marks,
+                        startTime: t.startTime,
+                        endTime: t.endTime
                     };
                 });
             }


### PR DESCRIPTION
Тhe DevTools/PerformanceTracker application needs this data in order to work both with the new data format and with older version. 