### PR TITLE
Improve workspace events when the frame is a platform

### DIFF
--- a/packages/workspaces-api/changelog.md
+++ b/packages/workspaces-api/changelog.md
@@ -1,3 +1,5 @@
+1.7.5
+fix: started firing open and close workspace events when the last workspace in a frame acting like a platform has been closed
 1.7.4
 feat: added getWorkspaceById method and made internal performance optimizations
 1.7.3

--- a/packages/workspaces-api/src/controllers/main.ts
+++ b/packages/workspaces-api/src/controllers/main.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Bridge } from "../communication/bridge";
-import { IsWindowInSwimlaneResult, WorkspaceCreateConfigProtocol, WorkspaceSnapshotResult, FrameSummariesResult, WorkspaceSummariesResult, LayoutSummariesResult, ExportedLayoutsResult, FrameSnapshotResult, AddItemResult, WindowStreamData, FrameStateResult, FrameBoundsResult } from "../types/protocol";
+import { IsWindowInSwimlaneResult, WorkspaceCreateConfigProtocol, WorkspaceSnapshotResult, FrameSummariesResult, WorkspaceSummariesResult, LayoutSummariesResult, ExportedLayoutsResult, FrameSnapshotResult, AddItemResult, WindowStreamData, FrameStateResult, FrameBoundsResult, WorkspaceStreamData } from "../types/protocol";
 import { OPERATIONS } from "../communication/constants";
 import { SubscriptionConfig, WorkspaceEventType, WorkspaceEventAction } from "../types/subscription";
 import { Workspace } from "../models/workspace";
@@ -98,6 +98,10 @@ export class MainController implements WorkspacesController {
 
     public getWorkspaceById(workspaceId: string): Promise<Workspace> {
         return this.base.fetchWorkspace(workspaceId);
+    }
+
+    public transformStreamPayloadToWorkspace(payload: WorkspaceStreamData): Promise<Workspace> {
+        return this.base.transformStreamPayloadToWorkspace(payload);
     }
 
     public async getWorkspace(predicate: (workspace: Workspace) => boolean): Promise<Workspace> {

--- a/packages/workspaces-api/src/main.ts
+++ b/packages/workspaces-api/src/main.ts
@@ -178,16 +178,7 @@ export const composeAPI = (glue: any, ioc: IoC): Glue42Workspaces.API => {
 
         checkThrowCallback(callback);
         const wrappedCallback = async (payload: WorkspaceStreamData): Promise<void> => {
-            const frameConfig: FrameCreateConfig = {
-                summary: payload.frameSummary
-            };
-            const frame = ioc.getModel<"frame">("frame", frameConfig);
-
-            const snapshot = (await controller.getSnapshot(payload.workspaceSummary.id, "workspace")) as WorkspaceSnapshotResult;
-
-            const workspaceConfig: WorkspaceIoCCreateConfig = { frame, snapshot };
-
-            const workspace = ioc.getModel<"workspace">("workspace", workspaceConfig);
+            const workspace = await controller.transformStreamPayloadToWorkspace(payload);
 
             callback(workspace);
         };

--- a/packages/workspaces-api/src/models/frame.ts
+++ b/packages/workspaces-api/src/models/frame.ts
@@ -195,7 +195,7 @@ export class Frame implements Glue42Workspaces.Frame {
         const myId = getData(this).summary.id;
 
         const wrappedCallback = async (payload: WorkspaceStreamData): Promise<void> => {
-            const workspace = await getData(this).controller.getWorkspaceById(payload.workspaceSummary.id);
+            const workspace = await getData(this).controller.transformStreamPayloadToWorkspace(payload);
             callback(workspace);
         };
 

--- a/packages/workspaces-api/src/shared/decoders.ts
+++ b/packages/workspaces-api/src/shared/decoders.ts
@@ -658,7 +658,8 @@ export const frameStreamDataDecoder: Decoder<FrameStreamData> = object({
 
 export const workspaceStreamDataDecoder: Decoder<WorkspaceStreamData> = object({
     workspaceSummary: workspaceSummaryResultDecoder,
-    frameSummary: frameSummaryDecoder
+    frameSummary: frameSummaryDecoder,
+    workspaceSnapshot: optional(workspaceSnapshotResultDecoder)
 });
 
 export const containerStreamDataDecoder: Decoder<ContainerStreamData> = object({

--- a/packages/workspaces-api/src/types/controller.ts
+++ b/packages/workspaces-api/src/types/controller.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Glue42Workspaces } from "../../workspaces";
-import { AddItemResult, WorkspaceSnapshotResult, FrameSnapshotResult } from "./protocol";
+import { AddItemResult, WorkspaceSnapshotResult, FrameSnapshotResult, WorkspaceStreamData } from "./protocol";
 import { SubscriptionConfig, WorkspaceEventType, WorkspaceEventAction } from "./subscription";
 import { RefreshChildrenConfig } from "./privateData";
 import { Child, ContainerLockConfig, SubParentTypes } from "./builders";
@@ -19,6 +19,7 @@ export interface WorkspacesController {
     getFrame(selector: { windowId?: string; predicate?: (frame: Glue42Workspaces.Frame) => boolean }): Promise<Glue42Workspaces.Frame>;
     getFrames(predicate?: (frame: Glue42Workspaces.Frame) => boolean): Promise<Glue42Workspaces.Frame[]>;
     getWorkspaceById(workspaceId: string): Promise<Glue42Workspaces.Workspace>;
+    transformStreamPayloadToWorkspace(payload: WorkspaceStreamData): Promise<Glue42Workspaces.Workspace>;
     getWorkspace(predicate: (workspace: Glue42Workspaces.Workspace) => boolean): Promise<Glue42Workspaces.Workspace>;
     getWorkspaces(predicate?: (workspace: Glue42Workspaces.Workspace) => boolean): Promise<Glue42Workspaces.Workspace[]>;
     getWorkspacesByFrameId(frameId: string): Promise<Glue42Workspaces.Workspace[]>;

--- a/packages/workspaces-api/src/types/protocol.ts
+++ b/packages/workspaces-api/src/types/protocol.ts
@@ -273,9 +273,12 @@ export interface FrameStreamData {
     frameSummary: FrameSummaryResult;
 }
 
+// the optional workspaceSnapshot is expected only when the last workspace in a Core platform-frame is being closed, which triggers the creation of a default workspace 
+// reason: explicit snapshot in this case will make sure that even if new new workspace was quickly closed (spamming of the close button), the event will provide correct data
 export interface WorkspaceStreamData {
     workspaceSummary: WorkspaceSummaryResult;
     frameSummary: FrameSummaryResult;
+    workspaceSnapshot?: WorkspaceSnapshotResult;
 }
 
 export interface ContainerStreamData {

--- a/packages/workspaces-ui-core/changelog.md
+++ b/packages/workspaces-ui-core/changelog.md
@@ -1,3 +1,5 @@
+1.4.5
+fix: started firing open and close workspace events when the last workspace in a frame acting like a platform has been closed
 1.4.4
 chore: bump due to dependencies update
 1.4.3

--- a/packages/workspaces-ui-core/src/export.ts
+++ b/packages/workspaces-ui-core/src/export.ts
@@ -17,8 +17,6 @@ window.addEventListener("beforeunload", () => {
     if (done) {
         done();
     }
-
-    return "Are you sure you want to leave? changes will be lost";
 });
 
 const init = (glue: Glue42Web.API, componentFactory?: ComponentFactory) => {

--- a/packages/workspaces-ui-core/src/layout/controller.ts
+++ b/packages/workspaces-ui-core/src/layout/controller.ts
@@ -293,7 +293,7 @@ export class LayoutController {
             type: "component",
             workspacesConfig: {},
             id,
-            noTabHeader: config.workspacesOptions?.noTabHeader,
+            noTabHeader: config?.workspacesOptions?.noTabHeader,
             title: (config?.workspacesOptions as any)?.title || this._configFactory.getWorkspaceTitle(store.workspaceTitles)
         };
 
@@ -314,8 +314,6 @@ export class LayoutController {
         }
 
         this.setupContentLayouts(id);
-
-        this.emitter.raiseEvent("workspace-added", { workspace: store.getById(id) });
     }
 
     public reinitializeWorkspace(id: string, config: GoldenLayout.Config): Promise<unknown> {
@@ -329,9 +327,8 @@ export class LayoutController {
 
     public removeWorkspace(workspaceId: string): void {
         const workspaceToBeRemoved = store.getWorkspaceLayoutItemById(workspaceId);
-
         if (!workspaceToBeRemoved) {
-            throw new Error(`Could find workspace to remove with id ${workspaceId}`);
+            throw new Error(`Could not find workspace to remove with id ${workspaceId}`);
         }
         store.removeById(workspaceId);
         workspaceToBeRemoved.remove();
@@ -1371,7 +1368,7 @@ export class LayoutController {
                 return;
             }
 
-            const wrapper = new WorkspaceWindowWrapper(this._stateResolver,tab.contentItem, this._frameId);
+            const wrapper = new WorkspaceWindowWrapper(this._stateResolver, tab.contentItem, this._frameId);
 
             if ((layout.config.workspacesOptions as any).showWindowCloseButtons === false && wrapper.showCloseButton !== true) {
                 uiExecutor.hideWindowCloseButton(tab.contentItem);

--- a/packages/workspaces-ui-core/src/manager.ts
+++ b/packages/workspaces-ui-core/src/manager.ts
@@ -1390,7 +1390,7 @@ export class WorkspacesManager {
         }
     }
 
-    private handleOnWorkspaceAddedWithSnapshot(workspace: Workspace) {
+    private handleOnWorkspaceAddedWithSnapshot(workspace: Workspace): void {
         const allOtherWindows = store.workspaceIds.filter((wId) => wId !== workspace.id).reduce((acc, w) => {
             return [...acc, ...store.getById(w).windows];
         }, []);
@@ -1399,6 +1399,7 @@ export class WorkspacesManager {
             action: "opened",
             payload: {
                 frameSummary: { id: this._frameId },
+                workspaceSnapshot: snapshot,
                 workspaceSummary: this.stateResolver.getWorkspaceSummary(workspace.id)
             }
         });

--- a/packages/workspaces-ui-core/src/types/events.ts
+++ b/packages/workspaces-ui-core/src/types/events.ts
@@ -1,4 +1,4 @@
-import { ContainerSummary } from "./internal";
+import { ContainerSummary, WorkspaceSnapshot } from "./internal";
 
 export type EventType = "window" | "workspace" | "frame" | "container";
 export type EventActionType = WindowEventAction | WorkspaceEventAction | FrameEventAction | ContainerEventAction;
@@ -46,6 +46,7 @@ export interface WorkspaceEventPayload {
             name: string;
         };
     };
+    workspaceSnapshot?: WorkspaceSnapshot;
     frameSummary: {
         id: string;
     };


### PR DESCRIPTION
##  Event improvements
Improved the event flow so the case in which the workspaces frame is a platform and there is an attempt to close the last workspace can be detected from a user using the API.
Issue for reference #234 