### PR TITLE
Added a GetPermission method to the Notifications API

### DIFF
--- a/e2e/config/gtf/index.ts
+++ b/e2e/config/gtf/index.ts
@@ -24,11 +24,13 @@ declare const GlueWorkspaces: WorkspacesFactoryFunction;
 declare const GlueWebPlatform: Glue42WebPlatformFactoryFunction;
 
 const setupNotifications = () => {
+    window.notificationsFakeTriggerClick = false;
+    window.notificationsFakePermission = "granted";
+    
     window.sinonSandbox = sinon.createSandbox();
 
     window.showNotificationFake = window.sinonSandbox.fake.resolves({});
     window.notificationConstructorFake = window.sinonSandbox.fake();
-    window.notificationsFakeTriggerClick = false;
 
     window.Notification = class FakeNotification {
         constructor(title: string, options: any) {
@@ -46,7 +48,11 @@ const setupNotifications = () => {
         }
 
         static requestPermission() {
-            return "granted";
+            return window.notificationsFakePermission;
+        }
+
+        static get permission() {
+            return window.notificationsFakePermission;
         }
 
         onclick: any;

--- a/e2e/tests/notifications/getPermission.spec.js
+++ b/e2e/tests/notifications/getPermission.spec.js
@@ -1,0 +1,37 @@
+describe("getPermission ", () => {
+    before(() => coreReady);
+
+    beforeEach(() => window.notificationsFakePermission = "granted");
+
+    afterEach(() => {
+        window.sinonSandbox.reset();
+        window.notificationsFakePermission = "granted";
+    });
+
+    it("should resolve", async () => {
+        await glue.notifications.getPermission();
+    });
+
+    it("should resolve with granted by default, because of setup", async () => {
+        const permission = await glue.notifications.getPermission();
+
+        expect(permission).to.eql("granted");
+    });
+
+    it("should resolve with default, when it is default", async () => {
+        window.notificationsFakePermission = "default"
+
+        const permission = await glue.notifications.getPermission();
+
+        expect(permission).to.eql("default");
+    });
+
+    it("should resolve with denied, when it is denied", async () => {
+        window.notificationsFakePermission = "denied"
+
+        const permission = await glue.notifications.getPermission();
+
+        expect(permission).to.eql("denied");
+    });
+
+});

--- a/e2e/tests/notifications/raise.spec.js
+++ b/e2e/tests/notifications/raise.spec.js
@@ -1,6 +1,9 @@
 describe("raise ", () => {
 
     before(() => coreReady);
+
+    beforeEach(() => window.notificationsFakePermission = "granted");
+
     afterEach(() => {
         window.sinonSandbox.reset();
         window.notificationsFakeTriggerClick = false;

--- a/e2e/tests/notifications/requestPermission.spec.js
+++ b/e2e/tests/notifications/requestPermission.spec.js
@@ -1,0 +1,31 @@
+describe("requestPermission ", () => {
+    before(() => coreReady);
+
+    beforeEach(() => window.notificationsFakePermission = "granted");
+
+    afterEach(() => {
+        window.sinonSandbox.reset();
+        window.notificationsFakePermission = "granted";
+    });
+
+    it("should resolve", async () => {
+        await glue.notifications.requestPermission();
+    });
+
+    it("should resolve with true, when permission is granted", async () => {
+        window.notificationsFakePermission = "granted";
+
+        const permission = await glue.notifications.requestPermission();
+
+        expect(permission).to.be.true;
+    });
+
+    it("should resolve with false when permission is not granted", async () => {
+        window.notificationsFakePermission = "denied";
+
+        const permission = await glue.notifications.requestPermission();
+
+        expect(permission).to.be.false;
+    });
+
+});

--- a/packages/web-platform/changelog.md
+++ b/packages/web-platform/changelog.md
@@ -1,3 +1,5 @@
+1.7.1
+feat: added support for getPermission
 1.7.0
 feat: added isSelected to the workspace object and dependencies update inline with 3.12 Enterprise release
 1.6.6

--- a/packages/web-platform/src/libs/notifications/controller.ts
+++ b/packages/web-platform/src/libs/notifications/controller.ts
@@ -4,8 +4,8 @@ import { BridgeOperation, LibController } from "../../common/types";
 import { GlueController } from "../../controllers/glue";
 import { ServiceWorkerController } from "../../controllers/serviceWorker";
 import logger from "../../shared/logger";
-import { notificationsOperationDecoder, permissionRequestResultDecoder, raiseNotificationDecoder } from "./decoders";
-import { GlueNotificationData, NotificationEventPayload, NotificationsOperationsTypes, PermissionRequestResult, RaiseNotificationConfig } from "./types";
+import { notificationsOperationDecoder, permissionQueryResultDecoder, permissionRequestResultDecoder, raiseNotificationDecoder } from "./decoders";
+import { GlueNotificationData, NotificationEventPayload, NotificationsOperationsTypes, PermissionQueryResult, PermissionRequestResult, RaiseNotificationConfig } from "./types";
 
 export class NotificationsController implements LibController {
 
@@ -13,7 +13,8 @@ export class NotificationsController implements LibController {
 
     private operations: { [key in NotificationsOperationsTypes]: BridgeOperation } = {
         raiseNotification: { name: "raiseNotification", execute: this.handleRaiseNotification.bind(this), dataDecoder: raiseNotificationDecoder },
-        requestPermission: { name: "requestPermission", resultDecoder: permissionRequestResultDecoder, execute: this.handleRequestPermission.bind(this) }
+        requestPermission: { name: "requestPermission", resultDecoder: permissionRequestResultDecoder, execute: this.handleRequestPermission.bind(this) },
+        getPermission: { name: "getPermission", resultDecoder: permissionQueryResultDecoder, execute: this.handleGetPermission.bind(this) }
     }
 
     constructor(
@@ -123,6 +124,17 @@ export class NotificationsController implements LibController {
 
         this.logger?.trace(`[${commandId}] notification with a title: ${settings.title} was successfully raised`);
     }
+
+    private async handleGetPermission(_: unknown, commandId: string): Promise<PermissionQueryResult> {
+        this.logger?.trace(`[${commandId}] handling a get permission message`);
+
+        const permissionValue = Notification.permission;
+
+        this.logger?.trace(`[${commandId}] permission for raising notifications is: ${permissionValue}`);
+
+        return { permission: permissionValue };
+    }
+
 
     private async handleRequestPermission(_: unknown, commandId: string): Promise<PermissionRequestResult> {
         this.logger?.trace(`[${commandId}] handling a request permission message`);

--- a/packages/web-platform/src/libs/notifications/decoders.ts
+++ b/packages/web-platform/src/libs/notifications/decoders.ts
@@ -1,11 +1,12 @@
 import { Glue42Web } from "@glue42/web";
 import { anyJson, array, boolean, constant, Decoder, number, object, oneOf, optional, string } from "decoder-validate";
 import { nonEmptyStringDecoder, nonNegativeNumberDecoder } from "../../shared/decoders";
-import { NotificationsOperationsTypes, PermissionRequestResult, RaiseNotificationConfig } from "./types";
+import { NotificationsOperationsTypes, PermissionQueryResult, PermissionRequestResult, RaiseNotificationConfig } from "./types";
 
-export const notificationsOperationDecoder: Decoder<NotificationsOperationsTypes> = oneOf<"raiseNotification" | "requestPermission">(
+export const notificationsOperationDecoder: Decoder<NotificationsOperationsTypes> = oneOf<"raiseNotification" | "requestPermission" | "getPermission">(
     constant("raiseNotification"),
-    constant("requestPermission")
+    constant("requestPermission"),
+    constant("getPermission")
 );
 
 
@@ -56,4 +57,12 @@ export const raiseNotificationDecoder: Decoder<RaiseNotificationConfig> = object
 
 export const permissionRequestResultDecoder: Decoder<PermissionRequestResult> = object({
     permissionGranted: boolean()
+});
+
+export const permissionQueryResultDecoder: Decoder<PermissionQueryResult> = object({
+    permission: oneOf<"default" | "granted" | "denied">(
+        constant("default"),
+        constant("granted"),
+        constant("denied")
+    )
 });

--- a/packages/web-platform/src/libs/notifications/types.ts
+++ b/packages/web-platform/src/libs/notifications/types.ts
@@ -1,6 +1,8 @@
 import { Glue42Web } from "@glue42/web";
 
-export type NotificationsOperationsTypes = "raiseNotification" | "requestPermission";
+export type NotificationsOperationsTypes = "raiseNotification" | "requestPermission" | "getPermission";
+
+export type NotificationPermissionTypes = "default" | "granted" | "denied";
 
 export interface RaiseNotificationConfig {
     settings: Glue42Web.Notifications.RaiseOptions;
@@ -16,6 +18,10 @@ export interface GlueNotificationData {
 
 export interface PermissionRequestResult {
     permissionGranted: boolean;
+}
+
+export interface PermissionQueryResult {
+    permission: NotificationPermissionTypes;
 }
 
 export interface NotificationEventPayload {

--- a/packages/web/changelog.md
+++ b/packages/web/changelog.md
@@ -1,3 +1,5 @@
+2.3.1
+feat: added getPermission method to the api
 2.3.0
 chore: bump due to dependencies update inline with 3.12 Enterprise release
 2.2.5

--- a/packages/web/src/notifications/controller.ts
+++ b/packages/web/src/notifications/controller.ts
@@ -5,7 +5,7 @@ import { GlueBridge } from "../communication/bridge";
 import { glue42NotificationOptionsDecoder, notificationsOperationTypesDecoder } from "../shared/decoders";
 import { IoC } from "../shared/ioc";
 import { LibController } from "../shared/types";
-import { NotificationEventPayload, operations, PermissionRequestResult, RaiseNotification } from "./protocol";
+import { NotificationEventPayload, operations, PermissionQueryResult, PermissionRequestResult, RaiseNotification } from "./protocol";
 import { generate } from "shortid";
 
 export class NotificationsController implements LibController {
@@ -60,10 +60,18 @@ export class NotificationsController implements LibController {
     private toApi(): Glue42Web.Notifications.API {
         const api: Glue42Web.Notifications.API = {
             raise: this.raise.bind(this),
-            requestPermission: this.requestPermission.bind(this)
+            requestPermission: this.requestPermission.bind(this),
+            getPermission: this.getPermission.bind(this)
         };
 
         return Object.freeze(api);
+    }
+
+    private async getPermission(): Promise<"default" | "granted" | "denied"> {
+
+        const queryResult = await this.bridge.send<void, PermissionQueryResult>("notifications", operations.getPermission, undefined);
+
+        return queryResult.permission;
     }
 
     private async requestPermission(): Promise<boolean> {

--- a/packages/web/src/notifications/protocol.ts
+++ b/packages/web/src/notifications/protocol.ts
@@ -1,14 +1,17 @@
 import { Glue42Web } from "../../web";
-import { notificationEventPayloadDecoder, permissionRequestResultDecoder, raiseNotificationDecoder } from "../shared/decoders";
+import { notificationEventPayloadDecoder, permissionQueryResultDecoder, permissionRequestResultDecoder, raiseNotificationDecoder } from "../shared/decoders";
 import { BridgeOperation } from "../shared/types";
 
-export type NotificationsOperationTypes = "raiseNotification" | "requestPermission" | "notificationShow" | "notificationClick";
+export type NotificationsOperationTypes = "raiseNotification" | "requestPermission" | "notificationShow" | "notificationClick" | "getPermission";
+
+export type NotificationPermissionTypes = "default" | "granted" | "denied";
 
 export const operations: { [key in NotificationsOperationTypes]: BridgeOperation } = {
     raiseNotification: { name: "raiseNotification", dataDecoder: raiseNotificationDecoder },
     requestPermission: { name: "requestPermission", resultDecoder: permissionRequestResultDecoder },
     notificationShow: { name: "notificationShow", dataDecoder: notificationEventPayloadDecoder },
-    notificationClick: { name: "notificationClick", dataDecoder: notificationEventPayloadDecoder }
+    notificationClick: { name: "notificationClick", dataDecoder: notificationEventPayloadDecoder },
+    getPermission: { name: "getPermission", resultDecoder: permissionQueryResultDecoder }
 };
 
 export interface RaiseNotification {
@@ -18,6 +21,10 @@ export interface RaiseNotification {
 
 export interface PermissionRequestResult {
     permissionGranted: boolean;
+}
+
+export interface PermissionQueryResult {
+    permission: NotificationPermissionTypes;
 }
 
 export interface NotificationEventPayload {

--- a/packages/web/src/shared/decoders.ts
+++ b/packages/web/src/shared/decoders.ts
@@ -6,7 +6,7 @@ import { AllLayoutsFullConfig, AllLayoutsSummariesResult, GetAllLayoutsConfig, L
 import { HelloSuccess, OpenWindowConfig, CoreWindowData, WindowHello, WindowOperationTypes, SimpleWindowCommand, WindowTitleConfig, WindowBoundsResult, WindowMoveResizeConfig, WindowUrlResult, FrameWindowBoundsResult } from "../windows/protocol";
 import { IntentsOperationTypes, WrappedIntentFilter, WrappedIntents } from "../intents/protocol";
 import { LibDomains } from "./types";
-import { NotificationEventPayload, NotificationsOperationTypes, PermissionRequestResult, RaiseNotification } from "../notifications/protocol";
+import { NotificationEventPayload, NotificationsOperationTypes, PermissionQueryResult, PermissionRequestResult, RaiseNotification } from "../notifications/protocol";
 
 export const nonEmptyStringDecoder: Decoder<string> = string().where((s) => s.length > 0, "Expected a non-empty string");
 export const nonNegativeNumberDecoder: Decoder<number> = number().where((num) => num >= 0, "Expected a non-negative number");
@@ -59,11 +59,12 @@ export const layoutsOperationTypesDecoder: Decoder<LayoutsOperationTypes> = oneO
     constant("remove")
 );
 
-export const notificationsOperationTypesDecoder: Decoder<NotificationsOperationTypes> = oneOf<"raiseNotification" | "requestPermission" | "notificationShow" | "notificationClick">(
+export const notificationsOperationTypesDecoder: Decoder<NotificationsOperationTypes> = oneOf<"raiseNotification" | "requestPermission" | "notificationShow" | "notificationClick" | "getPermission">(
     constant("raiseNotification"),
     constant("requestPermission"),
     constant("notificationShow"),
-    constant("notificationClick")
+    constant("notificationClick"),
+    constant("getPermission")
 );
 
 export const windowRelativeDirectionDecoder: Decoder<Glue42Web.Windows.RelativeDirection> = oneOf<"top" | "left" | "right" | "bottom">(
@@ -583,6 +584,14 @@ export const raiseNotificationDecoder: Decoder<RaiseNotification> = object({
 
 export const permissionRequestResultDecoder: Decoder<PermissionRequestResult> = object({
     permissionGranted: boolean()
+});
+
+export const permissionQueryResultDecoder: Decoder<PermissionQueryResult> = object({
+    permission: oneOf<"default" | "granted" | "denied">(
+        constant("default"),
+        constant("granted"),
+        constant("denied")
+    )
 });
 
 export const notificationEventPayloadDecoder: Decoder<NotificationEventPayload> = object({

--- a/packages/web/web.d.ts
+++ b/packages/web/web.d.ts
@@ -531,6 +531,9 @@ export namespace Glue42Web {
              * @param notification notification options
              */
             raise(notification: RaiseOptions): Promise<Notification>;
+
+            getPermission?(): Promise<"default" | "granted" | "denied">;
+
             requestPermission?(): Promise<boolean>;
         }
 


### PR DESCRIPTION
glue.notifications.getPermission() returns the native browser permission level of the platform, to which the client is connected and is therefore responsible for raising browser notification toasts. The permissions levels are the standard levels as defined in the web standard:
- "denied"
- "default"
- "granted"